### PR TITLE
feat: implement friendly theme and core screens

### DIFF
--- a/lib/app/main_shell.dart
+++ b/lib/app/main_shell.dart
@@ -3,10 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
 import 'package:peopleslab/features/home/presentation/home_page.dart';
 import 'package:peopleslab/features/search/presentation/search_page.dart';
-import 'package:peopleslab/features/auth/presentation/controllers/auth_controller.dart';
-import 'package:peopleslab/core/theme/theme_provider.dart';
-import 'package:peopleslab/common/widgets/app_button.dart';
-import 'package:peopleslab/core/l10n/l10n_x.dart';
+import 'package:peopleslab/features/favorites/presentation/favorites_page.dart';
+import 'package:peopleslab/features/profile/presentation/profile_page.dart';
 
 class MainShell extends ConsumerWidget {
   const MainShell({super.key});
@@ -21,8 +19,8 @@ class MainShell extends ConsumerWidget {
         children: const [
           HomePage(),
           SearchPage(),
-          _FavoritesPage(),
-          _ProfilePage(),
+          FavoritesPage(),
+          ProfilePage(),
         ],
       ),
       bottomNavigationBar: NavigationBar(
@@ -52,100 +50,6 @@ class MainShell extends ConsumerWidget {
             label: 'Профіль',
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _FavoritesPage extends StatelessWidget {
-  const _FavoritesPage();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: Text(
-            'Поки що порожньо',
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _ProfilePage extends ConsumerWidget {
-  const _ProfilePage();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final auth = ref.watch(authControllerProvider);
-    final user = auth.user;
-    final theme = Theme.of(context);
-    final mode = ref.watch(themeModeProvider);
-
-    final s = context.l10n;
-    return Scaffold(
-      body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            if (user != null)
-              ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: CircleAvatar(
-                  child: Text(
-                    (user.email.isNotEmpty ? user.email[0] : '?').toUpperCase(),
-                  ),
-                ),
-                title: Text(user.email),
-                subtitle: Text('ID: ${user.id}'),
-              )
-            else
-              const ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: CircleAvatar(child: Icon(Icons.person)),
-                title: Text('Користувач'),
-                subtitle: Text('Не знайдено даних користувача'),
-              ),
-            const SizedBox(height: 24),
-            Text('Тема', style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            SegmentedButton<ThemeMode>(
-              segments: const [
-                ButtonSegment(
-                  value: ThemeMode.system,
-                  label: Text('Авто'),
-                  icon: Icon(Icons.brightness_auto_rounded),
-                ),
-                ButtonSegment(
-                  value: ThemeMode.light,
-                  label: Text('Світла'),
-                  icon: Icon(Icons.light_mode_rounded),
-                ),
-                ButtonSegment(
-                  value: ThemeMode.dark,
-                  label: Text('Темна'),
-                  icon: Icon(Icons.dark_mode_rounded),
-                ),
-              ],
-              selected: {mode},
-              onSelectionChanged: (s) {
-                if (s.isNotEmpty) {
-                  ref.read(themeModeProvider.notifier).state = s.first;
-                }
-              },
-            ),
-            const SizedBox(height: 32),
-            AppButton.tonal(
-              onPressed: () async {
-                await ref.read(authControllerProvider.notifier).signOut();
-              },
-              label: s.action_sign_out,
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/common/widgets/search_field.dart
+++ b/lib/common/widgets/search_field.dart
@@ -47,7 +47,7 @@ class AppSearchField extends StatelessWidget {
             decoration: ShapeDecoration(
               color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14),
+                borderRadius: BorderRadius.circular(16),
               ),
             ),
             child: IconButton(

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart';
 class AppColors {
   AppColors._();
 
-  // Brand primary (blue) inspired by modern delivery apps, but blue.
-  static const Color primary = Color(0xFF2563EB); // Blue 600
-  static const Color primaryDark = Color(0xFF1D4ED8); // Blue 700
+  // Brand primary green inspired by friendly, fresh vibes.
+  static const Color primary = Color(0xFF00A86B); // Emerald 600
+  static const Color primaryDark = Color(0xFF00714D); // Darker emerald
 
   // Supporting colors (kept minimal; rely on ColorScheme for variants).
   static const Color success = Color(0xFF16A34A); // Green 600

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:peopleslab/core/theme/app_colors.dart';
 
 class AppTheme {
@@ -10,9 +11,11 @@ class AppTheme {
       brightness: Brightness.light,
     );
 
-    final baseTextTheme = Typography.material2021(
-      platform: TargetPlatform.android,
-    ).black;
+    final baseTextTheme = GoogleFonts.nunitoTextTheme(
+      Typography.material2021(
+        platform: TargetPlatform.android,
+      ).black,
+    );
 
     return ThemeData(
       useMaterial3: true,
@@ -30,7 +33,7 @@ class AppTheme {
             color: selected
                 ? colorScheme.primary
                 : colorScheme.onSurfaceVariant,
-            size: selected ? 26 : 24,
+            size: selected ? 28 : 24,
           );
         }),
         // No labels are shown; text styles are not needed
@@ -55,23 +58,23 @@ class AppTheme {
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
         fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 14,
-          vertical: 12,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide.none,
-        ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
         hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
         prefixIconColor: colorScheme.onSurfaceVariant,
         suffixIconColor: colorScheme.onSurfaceVariant,
       ),
       cardTheme: CardThemeData(
-        elevation: 0,
+        elevation: 1,
         color: colorScheme.surface,
         surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       ),
       dividerTheme: DividerThemeData(
         color: colorScheme.outlineVariant,
@@ -86,22 +89,22 @@ class AppTheme {
         ),
         labelStyle: TextStyle(color: colorScheme.onSurface),
         secondaryLabelStyle: TextStyle(color: colorScheme.onPrimary),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
         backgroundColor: colorScheme.surface,
         selectedItemColor: colorScheme.primary,
         unselectedItemColor: colorScheme.onSurfaceVariant,
         type: BottomNavigationBarType.fixed,
-        selectedIconTheme: const IconThemeData(size: 26),
+        selectedIconTheme: const IconThemeData(size: 28),
         unselectedIconTheme: const IconThemeData(size: 24),
       ),
       filledButtonTheme: FilledButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
           textStyle: WidgetStatePropertyAll(
             baseTextTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
@@ -112,7 +115,7 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
           side: WidgetStatePropertyAll(
             BorderSide(color: colorScheme.outlineVariant),
@@ -123,7 +126,7 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
         ),
       ),
@@ -135,7 +138,7 @@ class AppTheme {
         ),
       ),
       listTileTheme: ListTileThemeData(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         selectedColor: colorScheme.primary,
         iconColor: colorScheme.onSurfaceVariant,
       ),
@@ -148,9 +151,11 @@ class AppTheme {
       brightness: Brightness.dark,
     );
 
-    final baseTextTheme = Typography.material2021(
-      platform: TargetPlatform.android,
-    ).white;
+    final baseTextTheme = GoogleFonts.nunitoTextTheme(
+      Typography.material2021(
+        platform: TargetPlatform.android,
+      ).white,
+    );
 
     return ThemeData(
       useMaterial3: true,
@@ -168,7 +173,7 @@ class AppTheme {
             color: selected
                 ? colorScheme.primary
                 : colorScheme.onSurfaceVariant,
-            size: selected ? 26 : 24,
+            size: selected ? 28 : 24,
           );
         }),
         // No labels are shown; text styles are not needed
@@ -193,23 +198,23 @@ class AppTheme {
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
         fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 14,
-          vertical: 12,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide.none,
-        ),
+          contentPadding: const EdgeInsets.symmetric(
+            horizontal: 16,
+            vertical: 12,
+          ),
+          border: OutlineInputBorder(
+            borderRadius: BorderRadius.circular(16),
+            borderSide: BorderSide.none,
+          ),
         hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
         prefixIconColor: colorScheme.onSurfaceVariant,
         suffixIconColor: colorScheme.onSurfaceVariant,
       ),
       cardTheme: CardThemeData(
-        elevation: 0,
+        elevation: 1,
         color: colorScheme.surface,
         surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       ),
       dividerTheme: DividerThemeData(
         color: colorScheme.outlineVariant,
@@ -224,22 +229,22 @@ class AppTheme {
         ),
         labelStyle: TextStyle(color: colorScheme.onSurface),
         secondaryLabelStyle: TextStyle(color: colorScheme.onPrimary),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
         backgroundColor: colorScheme.surface,
         selectedItemColor: colorScheme.primary,
         unselectedItemColor: colorScheme.onSurfaceVariant,
         type: BottomNavigationBarType.fixed,
-        selectedIconTheme: const IconThemeData(size: 26),
+        selectedIconTheme: const IconThemeData(size: 28),
         unselectedIconTheme: const IconThemeData(size: 24),
       ),
       filledButtonTheme: FilledButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
           textStyle: WidgetStatePropertyAll(
             baseTextTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
@@ -250,7 +255,7 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
           side: WidgetStatePropertyAll(
             BorderSide(color: colorScheme.outlineVariant),
@@ -261,7 +266,7 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
           ),
         ),
       ),
@@ -273,7 +278,7 @@ class AppTheme {
         ),
       ),
       listTileTheme: ListTileThemeData(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
         selectedColor: colorScheme.primary,
         iconColor: colorScheme.onSurfaceVariant,
       ),

--- a/lib/features/favorites/presentation/favorites_page.dart
+++ b/lib/features/favorites/presentation/favorites_page.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+
+/// Displays user's saved restaurants or items.
+class FavoritesPage extends StatelessWidget {
+  const FavoritesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.favorite_rounded, size: 64, color: colorScheme.primary),
+              const SizedBox(height: 16),
+              Text(
+                'No favourites yet',
+                style: theme.textTheme.titleMedium,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/onboarding/presentation/onboarding_page.dart
+++ b/lib/features/onboarding/presentation/onboarding_page.dart
@@ -4,35 +4,113 @@ import 'package:peopleslab/core/router/app_router.dart';
 import 'package:peopleslab/core/l10n/l10n_x.dart';
 import 'package:peopleslab/common/widgets/app_button.dart';
 
-class OnboardingPage extends StatelessWidget {
+/// Simple onboarding flow with three informative pages.
+class OnboardingPage extends StatefulWidget {
   const OnboardingPage({super.key});
 
   @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final _controller = PageController();
+  int _index = 0;
+
+  static final _pages = [
+    (
+      icon: Icons.eco_rounded,
+      title: 'Earn for good deeds',
+      desc: 'Collect points and level up your neighbourliness.',
+    ),
+    (
+      icon: Icons.receipt_long_rounded,
+      title: 'Go paperless',
+      desc: 'Store all your receipts in one tidy place.',
+    ),
+    (
+      icon: Icons.handshake_rounded,
+      title: 'Support local projects',
+      desc: 'Spend earned points to make an impact.',
+    ),
+  ];
+
+  void _next() {
+    if (_index == _pages.length - 1) {
+      context.push(AppRoutes.signUp);
+    } else {
+      _controller.nextPage(
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
+      );
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final s = context.l10n;
     return Scaffold(
-      appBar: AppBar(title: Text(s.onboarding_appbar_title)),
-      body: Center(
+      body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(24.0),
+          padding: const EdgeInsets.all(24),
           child: Column(
-            mainAxisSize: MainAxisSize.min,
             children: [
-              Text(
-                s.brand_name,
-                style: const TextStyle(
-                  fontSize: 28,
-                  fontWeight: FontWeight.bold,
+              Expanded(
+                child: PageView.builder(
+                  controller: _controller,
+                  itemCount: _pages.length,
+                  onPageChanged: (i) => setState(() => _index = i),
+                  itemBuilder: (context, i) {
+                    final page = _pages[i];
+                    return Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Icon(page.icon, size: 120, color: colorScheme.primary),
+                        const SizedBox(height: 32),
+                        Text(
+                          page.title,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.headlineSmall?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        Text(
+                          page.desc,
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodyLarge,
+                        ),
+                      ],
+                    );
+                  },
                 ),
               ),
-              const SizedBox(height: 16),
-              Text(s.onboarding_intro, textAlign: TextAlign.center),
+              const SizedBox(height: 24),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  for (var i = 0; i < _pages.length; i++)
+                    Container(
+                      width: 8,
+                      height: 8,
+                      margin: const EdgeInsets.symmetric(horizontal: 4),
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: _index == i
+                            ? colorScheme.primary
+                            : colorScheme.outlineVariant,
+                      ),
+                    ),
+                ],
+              ),
               const SizedBox(height: 24),
               AppButton.primary(
-                onPressed: () => context.push(AppRoutes.signUp),
-                label: s.signup_create_account,
+                onPressed: _next,
+                label:
+                    _index == _pages.length - 1 ? s.signup_create_account : s.onboarding_cta,
               ),
-              const SizedBox(height: 12),
+              const SizedBox(height: 8),
               AppButton.text(
                 onPressed: () => context.push(AppRoutes.signIn),
                 label: s.cta_already_have_account,
@@ -44,3 +122,4 @@ class OnboardingPage extends StatelessWidget {
     );
   }
 }
+

--- a/lib/features/profile/presentation/profile_page.dart
+++ b/lib/features/profile/presentation/profile_page.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:peopleslab/core/theme/theme_provider.dart';
+import 'package:peopleslab/core/l10n/l10n_x.dart';
+import 'package:peopleslab/features/auth/presentation/controllers/auth_controller.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+
+/// Basic profile screen with theme switching and sign out.
+class ProfilePage extends ConsumerWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authControllerProvider);
+    final user = auth.user;
+    final theme = Theme.of(context);
+    final mode = ref.watch(themeModeProvider);
+    final s = context.l10n;
+    return Scaffold(
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            if (user != null)
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(
+                  child: Text(
+                    (user.email.isNotEmpty ? user.email[0] : '?').toUpperCase(),
+                  ),
+                ),
+                title: Text(user.email),
+                subtitle: Text('ID: ${user.id}'),
+              )
+            else
+              const ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(child: Icon(Icons.person)),
+                title: Text('User'),
+                subtitle: Text('No user data'),
+              ),
+            const SizedBox(height: 24),
+            Text('Theme', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            SegmentedButton<ThemeMode>(
+              segments: const [
+                ButtonSegment(
+                  value: ThemeMode.system,
+                  label: Text('Auto'),
+                  icon: Icon(Icons.brightness_auto_rounded),
+                ),
+                ButtonSegment(
+                  value: ThemeMode.light,
+                  label: Text('Light'),
+                  icon: Icon(Icons.light_mode_rounded),
+                ),
+                ButtonSegment(
+                  value: ThemeMode.dark,
+                  label: Text('Dark'),
+                  icon: Icon(Icons.dark_mode_rounded),
+                ),
+              ],
+              selected: {mode},
+              onSelectionChanged: (s) {
+                if (s.isNotEmpty) {
+                  ref.read(themeModeProvider.notifier).state = s.first;
+                }
+              },
+            ),
+            const SizedBox(height: 32),
+            AppButton.tonal(
+              onPressed: () async {
+                await ref.read(authControllerProvider.notifier).signOut();
+              },
+              label: s.action_sign_out,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   go_router: ^16.2.1
   intl: ^0.20.2
+  google_fonts: ^6.1.0
 
   # ВАЖЛИВО: тимчасово тримаємо 4.1.x, бо grpc >=4.2.0 вимагає meta ^1.17.0,
   # а flutter_test у твоєму SDK пінить meta на 1.16.0.


### PR DESCRIPTION
## Summary
- adopt a fresh green theme with custom typography, rounded shapes, and tuned component sizes
- add onboarding flow with page view slides and hook up profile & favourites tabs
- provide simple profile and favourites screens built with the new design

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0301db7108331b8ed25b20c380696