### PR TITLE
feat: build core UI scaffolding with theme and profile/favorites

### DIFF
--- a/lib/app/main_shell.dart
+++ b/lib/app/main_shell.dart
@@ -3,10 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
 import 'package:peopleslab/features/home/presentation/home_page.dart';
 import 'package:peopleslab/features/search/presentation/search_page.dart';
-import 'package:peopleslab/features/auth/presentation/controllers/auth_controller.dart';
-import 'package:peopleslab/core/theme/theme_provider.dart';
-import 'package:peopleslab/common/widgets/app_button.dart';
-import 'package:peopleslab/core/l10n/l10n_x.dart';
+import 'package:peopleslab/features/favorites/presentation/favorites_page.dart';
+import 'package:peopleslab/features/profile/presentation/profile_page.dart';
 
 class MainShell extends ConsumerWidget {
   const MainShell({super.key});
@@ -21,15 +19,14 @@ class MainShell extends ConsumerWidget {
         children: const [
           HomePage(),
           SearchPage(),
-          _FavoritesPage(),
-          _ProfilePage(),
+          FavoritesPage(),
+          ProfilePage(),
         ],
       ),
       bottomNavigationBar: NavigationBar(
         selectedIndex: index,
         onDestinationSelected: (i) =>
             ref.read(bottomNavIndexProvider.notifier).state = i,
-        // Height/indicator/colors are themed in AppTheme
         destinations: const [
           NavigationDestination(
             icon: Icon(Icons.home_outlined),
@@ -52,100 +49,6 @@ class MainShell extends ConsumerWidget {
             label: 'Профіль',
           ),
         ],
-      ),
-    );
-  }
-}
-
-class _FavoritesPage extends StatelessWidget {
-  const _FavoritesPage();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: Text(
-            'Поки що порожньо',
-            style: Theme.of(context).textTheme.bodyLarge,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class _ProfilePage extends ConsumerWidget {
-  const _ProfilePage();
-
-  @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final auth = ref.watch(authControllerProvider);
-    final user = auth.user;
-    final theme = Theme.of(context);
-    final mode = ref.watch(themeModeProvider);
-
-    final s = context.l10n;
-    return Scaffold(
-      body: SafeArea(
-        child: ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            if (user != null)
-              ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: CircleAvatar(
-                  child: Text(
-                    (user.email.isNotEmpty ? user.email[0] : '?').toUpperCase(),
-                  ),
-                ),
-                title: Text(user.email),
-                subtitle: Text('ID: ${user.id}'),
-              )
-            else
-              const ListTile(
-                contentPadding: EdgeInsets.zero,
-                leading: CircleAvatar(child: Icon(Icons.person)),
-                title: Text('Користувач'),
-                subtitle: Text('Не знайдено даних користувача'),
-              ),
-            const SizedBox(height: 24),
-            Text('Тема', style: theme.textTheme.titleMedium),
-            const SizedBox(height: 8),
-            SegmentedButton<ThemeMode>(
-              segments: const [
-                ButtonSegment(
-                  value: ThemeMode.system,
-                  label: Text('Авто'),
-                  icon: Icon(Icons.brightness_auto_rounded),
-                ),
-                ButtonSegment(
-                  value: ThemeMode.light,
-                  label: Text('Світла'),
-                  icon: Icon(Icons.light_mode_rounded),
-                ),
-                ButtonSegment(
-                  value: ThemeMode.dark,
-                  label: Text('Темна'),
-                  icon: Icon(Icons.dark_mode_rounded),
-                ),
-              ],
-              selected: {mode},
-              onSelectionChanged: (s) {
-                if (s.isNotEmpty) {
-                  ref.read(themeModeProvider.notifier).state = s.first;
-                }
-              },
-            ),
-            const SizedBox(height: 32),
-            AppButton.tonal(
-              onPressed: () async {
-                await ref.read(authControllerProvider.notifier).signOut();
-              },
-              label: s.action_sign_out,
-            ),
-          ],
-        ),
       ),
     );
   }

--- a/lib/common/widgets/search_field.dart
+++ b/lib/common/widgets/search_field.dart
@@ -45,9 +45,9 @@ class AppSearchField extends StatelessWidget {
           const SizedBox(width: 12),
           Ink(
             decoration: ShapeDecoration(
-              color: colorScheme.surfaceContainerHighest.withValues(alpha: 0.6),
+              color: colorScheme.surfaceVariant.withOpacity(0.6),
               shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(14),
+                borderRadius: BorderRadius.circular(12),
               ),
             ),
             child: IconButton(

--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -4,9 +4,10 @@ import 'package:flutter/material.dart';
 class AppColors {
   AppColors._();
 
-  // Brand primary (blue) inspired by modern delivery apps, but blue.
-  static const Color primary = Color(0xFF2563EB); // Blue 600
-  static const Color primaryDark = Color(0xFF1D4ED8); // Blue 700
+  // Brand palette: fresh emerald with warm accent.
+  static const Color primary = Color(0xFF00A86B); // Emerald 600
+  static const Color primaryDark = Color(0xFF00895A); // Darker emerald
+  static const Color secondary = Color(0xFFFFB74D); // Amber 300
 
   // Supporting colors (kept minimal; rely on ColorScheme for variants).
   static const Color success = Color(0xFF16A34A); // Green 600

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -4,107 +4,164 @@ import 'package:peopleslab/core/theme/app_colors.dart';
 class AppTheme {
   AppTheme._();
 
-  static ThemeData light() {
-    final colorScheme = ColorScheme.fromSeed(
+  static const double _radius = 12;
+
+  static TextTheme _textTheme(ColorScheme colors) {
+    const font = 'Roboto';
+    return TextTheme(
+      displayLarge: TextStyle(
+        fontFamily: font,
+        fontSize: 40,
+        fontWeight: FontWeight.w700,
+        color: colors.onSurface,
+      ),
+      displayMedium: TextStyle(
+        fontFamily: font,
+        fontSize: 32,
+        fontWeight: FontWeight.w700,
+        color: colors.onSurface,
+      ),
+      displaySmall: TextStyle(
+        fontFamily: font,
+        fontSize: 28,
+        fontWeight: FontWeight.w600,
+        color: colors.onSurface,
+      ),
+      headlineMedium: TextStyle(
+        fontFamily: font,
+        fontSize: 24,
+        fontWeight: FontWeight.w600,
+        color: colors.onSurface,
+      ),
+      headlineSmall: TextStyle(
+        fontFamily: font,
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+        color: colors.onSurface,
+      ),
+      titleLarge: TextStyle(
+        fontFamily: font,
+        fontSize: 18,
+        fontWeight: FontWeight.w600,
+        color: colors.onSurface,
+      ),
+      titleMedium: TextStyle(
+        fontFamily: font,
+        fontSize: 16,
+        fontWeight: FontWeight.w600,
+        color: colors.onSurface,
+      ),
+      titleSmall: TextStyle(
+        fontFamily: font,
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        color: colors.onSurface,
+      ),
+      bodyLarge: TextStyle(
+        fontFamily: font,
+        fontSize: 16,
+        fontWeight: FontWeight.w400,
+        color: colors.onSurface,
+      ),
+      bodyMedium: TextStyle(
+        fontFamily: font,
+        fontSize: 14,
+        fontWeight: FontWeight.w400,
+        color: colors.onSurface,
+      ),
+      bodySmall: TextStyle(
+        fontFamily: font,
+        fontSize: 12,
+        fontWeight: FontWeight.w400,
+        color: colors.onSurfaceVariant,
+      ),
+      labelLarge: TextStyle(
+        fontFamily: font,
+        fontSize: 14,
+        fontWeight: FontWeight.w600,
+        color: colors.onPrimary,
+      ),
+      labelMedium: TextStyle(
+        fontFamily: font,
+        fontSize: 12,
+        fontWeight: FontWeight.w500,
+        color: colors.onSurface,
+      ),
+      labelSmall: TextStyle(
+        fontFamily: font,
+        fontSize: 11,
+        fontWeight: FontWeight.w500,
+        color: colors.onSurfaceVariant,
+      ),
+    );
+  }
+
+  static ThemeData _theme(Brightness brightness) {
+    final scheme = ColorScheme.fromSeed(
       seedColor: AppColors.primary,
-      brightness: Brightness.light,
-    );
+      brightness: brightness,
+    ).copyWith(secondary: AppColors.secondary);
 
-    final baseTextTheme = Typography.material2021(
-      platform: TargetPlatform.android,
-    ).black;
+    final textTheme = _textTheme(scheme);
 
     return ThemeData(
       useMaterial3: true,
-      colorScheme: colorScheme,
-      scaffoldBackgroundColor: colorScheme.surface,
-      textTheme: baseTextTheme,
+      colorScheme: scheme,
+      textTheme: textTheme,
+      scaffoldBackgroundColor: scheme.surface,
+      appBarTheme: AppBarTheme(
+        backgroundColor: scheme.surface,
+        foregroundColor: scheme.onSurface,
+        elevation: 0,
+        centerTitle: true,
+      ),
+      cardTheme: CardTheme(
+        elevation: 1,
+        margin: EdgeInsets.zero,
+        color: scheme.surface,
+        surfaceTintColor: Colors.transparent,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(_radius),
+        ),
+      ),
+      dividerTheme: DividerThemeData(
+        color: scheme.outlineVariant,
+        thickness: 1,
+        space: 1,
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: scheme.surfaceVariant.withOpacity(0.5),
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(_radius),
+          borderSide: BorderSide.none,
+        ),
+        hintStyle: TextStyle(color: scheme.onSurfaceVariant),
+        prefixIconColor: scheme.onSurfaceVariant,
+        suffixIconColor: scheme.onSurfaceVariant,
+      ),
       navigationBarTheme: NavigationBarThemeData(
         height: 56,
-        backgroundColor: colorScheme.surface,
+        backgroundColor: scheme.surface,
         indicatorColor: Colors.transparent,
         labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
         iconTheme: WidgetStateProperty.resolveWith((states) {
           final selected = states.contains(WidgetState.selected);
           return IconThemeData(
-            color: selected
-                ? colorScheme.primary
-                : colorScheme.onSurfaceVariant,
+            color: selected ? scheme.primary : scheme.onSurfaceVariant,
             size: selected ? 26 : 24,
           );
         }),
-        // No labels are shown; text styles are not needed
-      ),
-      pageTransitionsTheme: const PageTransitionsTheme(
-        builders: {
-          TargetPlatform.android: ZoomPageTransitionsBuilder(),
-          TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-          TargetPlatform.macOS: ZoomPageTransitionsBuilder(),
-          TargetPlatform.linux: ZoomPageTransitionsBuilder(),
-          TargetPlatform.windows: ZoomPageTransitionsBuilder(),
-        },
-      ),
-      appBarTheme: AppBarTheme(
-        backgroundColor: colorScheme.surface,
-        foregroundColor: colorScheme.onSurface,
-        elevation: 0,
-        scrolledUnderElevation: 0,
-        centerTitle: true,
-        surfaceTintColor: Colors.transparent,
-      ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 14,
-          vertical: 12,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide.none,
-        ),
-        hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
-        prefixIconColor: colorScheme.onSurfaceVariant,
-        suffixIconColor: colorScheme.onSurfaceVariant,
-      ),
-      cardTheme: CardThemeData(
-        elevation: 0,
-        color: colorScheme.surface,
-        surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      ),
-      dividerTheme: DividerThemeData(
-        color: colorScheme.outlineVariant,
-        thickness: 1,
-        space: 1,
-      ),
-      chipTheme: ChipThemeData(
-        side: BorderSide.none,
-        selectedColor: colorScheme.primary.withValues(alpha: 0.12),
-        backgroundColor: colorScheme.surfaceContainerHighest.withValues(
-          alpha: 0.6,
-        ),
-        labelStyle: TextStyle(color: colorScheme.onSurface),
-        secondaryLabelStyle: TextStyle(color: colorScheme.onPrimary),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
-      ),
-      bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: colorScheme.surface,
-        selectedItemColor: colorScheme.primary,
-        unselectedItemColor: colorScheme.onSurfaceVariant,
-        type: BottomNavigationBarType.fixed,
-        selectedIconTheme: const IconThemeData(size: 26),
-        unselectedIconTheme: const IconThemeData(size: 24),
       ),
       filledButtonTheme: FilledButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(_radius)),
           ),
           textStyle: WidgetStatePropertyAll(
-            baseTextTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
           ),
         ),
       ),
@@ -112,171 +169,34 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(_radius)),
           ),
           side: WidgetStatePropertyAll(
-            BorderSide(color: colorScheme.outlineVariant),
-          ),
-        ),
-      ),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ButtonStyle(
-          minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            BorderSide(color: scheme.outlineVariant),
           ),
         ),
       ),
       iconButtonTheme: IconButtonThemeData(
         style: ButtonStyle(
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            RoundedRectangleBorder(borderRadius: BorderRadius.circular(_radius - 4)),
           ),
         ),
-      ),
-      listTileTheme: ListTileThemeData(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-        selectedColor: colorScheme.primary,
-        iconColor: colorScheme.onSurfaceVariant,
-      ),
-    );
-  }
-
-  static ThemeData dark() {
-    final colorScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.primaryDark,
-      brightness: Brightness.dark,
-    );
-
-    final baseTextTheme = Typography.material2021(
-      platform: TargetPlatform.android,
-    ).white;
-
-    return ThemeData(
-      useMaterial3: true,
-      colorScheme: colorScheme,
-      scaffoldBackgroundColor: colorScheme.surface,
-      textTheme: baseTextTheme,
-      navigationBarTheme: NavigationBarThemeData(
-        height: 56,
-        backgroundColor: colorScheme.surface,
-        indicatorColor: Colors.transparent,
-        labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
-        iconTheme: WidgetStateProperty.resolveWith((states) {
-          final selected = states.contains(WidgetState.selected);
-          return IconThemeData(
-            color: selected
-                ? colorScheme.primary
-                : colorScheme.onSurfaceVariant,
-            size: selected ? 26 : 24,
-          );
-        }),
-        // No labels are shown; text styles are not needed
-      ),
-      pageTransitionsTheme: const PageTransitionsTheme(
-        builders: {
-          TargetPlatform.android: ZoomPageTransitionsBuilder(),
-          TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-          TargetPlatform.macOS: ZoomPageTransitionsBuilder(),
-          TargetPlatform.linux: ZoomPageTransitionsBuilder(),
-          TargetPlatform.windows: ZoomPageTransitionsBuilder(),
-        },
-      ),
-      appBarTheme: AppBarTheme(
-        backgroundColor: colorScheme.surface,
-        foregroundColor: colorScheme.onSurface,
-        elevation: 0,
-        scrolledUnderElevation: 0,
-        centerTitle: true,
-        surfaceTintColor: Colors.transparent,
-      ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 14,
-          vertical: 12,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide.none,
-        ),
-        hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
-        prefixIconColor: colorScheme.onSurfaceVariant,
-        suffixIconColor: colorScheme.onSurfaceVariant,
-      ),
-      cardTheme: CardThemeData(
-        elevation: 0,
-        color: colorScheme.surface,
-        surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      ),
-      dividerTheme: DividerThemeData(
-        color: colorScheme.outlineVariant,
-        thickness: 1,
-        space: 1,
       ),
       chipTheme: ChipThemeData(
         side: BorderSide.none,
-        selectedColor: colorScheme.primary.withValues(alpha: 0.22),
-        backgroundColor: colorScheme.surfaceContainerHighest.withValues(
-          alpha: 0.5,
+        selectedColor: scheme.primary.withOpacity(0.12),
+        backgroundColor: scheme.surfaceVariant.withOpacity(0.6),
+        labelStyle: TextStyle(color: scheme.onSurface),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(_radius * 1.5),
         ),
-        labelStyle: TextStyle(color: colorScheme.onSurface),
-        secondaryLabelStyle: TextStyle(color: colorScheme.onPrimary),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
-      ),
-      bottomNavigationBarTheme: BottomNavigationBarThemeData(
-        backgroundColor: colorScheme.surface,
-        selectedItemColor: colorScheme.primary,
-        unselectedItemColor: colorScheme.onSurfaceVariant,
-        type: BottomNavigationBarType.fixed,
-        selectedIconTheme: const IconThemeData(size: 26),
-        unselectedIconTheme: const IconThemeData(size: 24),
-      ),
-      filledButtonTheme: FilledButtonThemeData(
-        style: ButtonStyle(
-          minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-          ),
-          textStyle: WidgetStatePropertyAll(
-            baseTextTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
-          ),
-        ),
-      ),
-      outlinedButtonTheme: OutlinedButtonThemeData(
-        style: ButtonStyle(
-          minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-          ),
-          side: WidgetStatePropertyAll(
-            BorderSide(color: colorScheme.outlineVariant),
-          ),
-        ),
-      ),
-      elevatedButtonTheme: ElevatedButtonThemeData(
-        style: ButtonStyle(
-          minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-          ),
-        ),
-      ),
-      iconButtonTheme: IconButtonThemeData(
-        style: ButtonStyle(
-          shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-          ),
-        ),
-      ),
-      listTileTheme: ListTileThemeData(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
-        selectedColor: colorScheme.primary,
-        iconColor: colorScheme.onSurfaceVariant,
       ),
     );
   }
+
+  static ThemeData light() => _theme(Brightness.light);
+
+  static ThemeData dark() => _theme(Brightness.dark);
 }

--- a/lib/features/favorites/presentation/favorites_page.dart
+++ b/lib/features/favorites/presentation/favorites_page.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+
+class FavoritesPage extends StatelessWidget {
+  const FavoritesPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colors = theme.colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.favorite_outline_rounded,
+                size: 64,
+                color: colors.primary,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Поки що порожньо',
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Додайте ресторани до обраного',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: colors.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/profile/presentation/profile_page.dart
+++ b/lib/features/profile/presentation/profile_page.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:peopleslab/features/auth/presentation/controllers/auth_controller.dart';
+import 'package:peopleslab/core/theme/theme_provider.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/core/l10n/l10n_x.dart';
+
+class ProfilePage extends ConsumerWidget {
+  const ProfilePage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final auth = ref.watch(authControllerProvider);
+    final user = auth.user;
+    final theme = Theme.of(context);
+    final mode = ref.watch(themeModeProvider);
+    final s = context.l10n;
+
+    return Scaffold(
+      body: SafeArea(
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            if (user != null)
+              ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(
+                  child: Text(
+                    (user.email.isNotEmpty ? user.email[0] : '?').toUpperCase(),
+                  ),
+                ),
+                title: Text(user.email),
+                subtitle: Text('ID: ${user.id}'),
+              )
+            else
+              const ListTile(
+                contentPadding: EdgeInsets.zero,
+                leading: CircleAvatar(child: Icon(Icons.person)),
+                title: Text('Користувач'),
+                subtitle: Text('Не знайдено даних користувача'),
+              ),
+            const SizedBox(height: 24),
+            Text('Тема', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            SegmentedButton<ThemeMode>(
+              segments: const [
+                ButtonSegment(
+                  value: ThemeMode.system,
+                  label: Text('Авто'),
+                  icon: Icon(Icons.brightness_auto_rounded),
+                ),
+                ButtonSegment(
+                  value: ThemeMode.light,
+                  label: Text('Світла'),
+                  icon: Icon(Icons.light_mode_rounded),
+                ),
+                ButtonSegment(
+                  value: ThemeMode.dark,
+                  label: Text('Темна'),
+                  icon: Icon(Icons.dark_mode_rounded),
+                ),
+              ],
+              selected: {mode},
+              onSelectionChanged: (s) {
+                if (s.isNotEmpty) {
+                  ref.read(themeModeProvider.notifier).state = s.first;
+                }
+              },
+            ),
+            const SizedBox(height: 32),
+            AppButton.tonal(
+              onPressed: () async {
+                await ref.read(authControllerProvider.notifier).signOut();
+              },
+              label: s.action_sign_out,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- create emerald/amber themed light and dark modes with custom typography and rounded components
- add standalone profile and favourites pages and wire into navigation
- refine search field styling to follow new spacing

## Testing
- `flutter analyze` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c0301db7108331b8ed25b20c380696