### PR TITLE
feat: add demo design screens

### DIFF
--- a/lib/features/demo/presentation/applications_page.dart
+++ b/lib/features/demo/presentation/applications_page.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+
+class ApplicationsPage extends StatelessWidget {
+  const ApplicationsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = const [
+      ('Відпустка', 'Розглядається від 7 робочих днів'),
+      ('Лікарняний', 'Розглядається від 1-2 годин'),
+      ('Вихідний', 'Розглядається від 1-2 годин'),
+      ('Отримання компенсації', 'Розглядається від 7 робочих днів'),
+    ];
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Заяви'),
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return Card(
+            margin: const EdgeInsets.only(bottom: 12),
+            child: ListTile(
+              title: Text(item.$1),
+              subtitle: Text(item.$2),
+              trailing: const Icon(Icons.arrow_forward_ios_rounded, size: 16),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/demo/presentation/gamification_page.dart
+++ b/lib/features/demo/presentation/gamification_page.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class GamificationPage extends StatelessWidget {
+  const GamificationPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Добросусідство')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Ваш рівень добросусідства',
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    'Максимальний рівень досяжності',
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  const SizedBox(height: 12),
+                  const LinearProgressIndicator(value: 0.7),
+                  const SizedBox(height: 8),
+                  Text(
+                    '34 000 / 50 000 балів',
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 16),
+          Card(
+            child: ListTile(
+              title: const Text('Файні новини'),
+              subtitle:
+                  const Text('Підтримайте проєкти та отримуйте бали'),
+              trailing:
+                  const Icon(Icons.arrow_forward_ios_rounded, size: 16),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/demo/presentation/receipt_detail_page.dart
+++ b/lib/features/demo/presentation/receipt_detail_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class ReceiptDetailPage extends StatelessWidget {
+  final String date;
+  final String store;
+  final double total;
+
+  const ReceiptDetailPage({
+    super.key,
+    required this.date,
+    required this.store,
+    required this.total,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final items = const [
+      ('Батон', 30.50),
+      ('Молоко', 40.00),
+      ('Сир', 98.40),
+    ];
+    return Scaffold(
+      appBar: AppBar(title: const Text('Деталі чеку')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(store, style: Theme.of(context).textTheme.titleLarge),
+          Text(date),
+          const SizedBox(height: 16),
+          for (final i in items)
+            ListTile(
+              title: Text(i.$1),
+              trailing: Text('${i.$2.toStringAsFixed(2)} ₴'),
+            ),
+          const Divider(),
+          ListTile(
+            title: const Text('Сума чеку'),
+            trailing: Text('${total.toStringAsFixed(2)} ₴'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/demo/presentation/receipts_page.dart
+++ b/lib/features/demo/presentation/receipts_page.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'receipt_detail_page.dart';
+
+class ReceiptsPage extends StatelessWidget {
+  const ReceiptsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final receipts = const [
+      ('12 грудня 2024', 'Супермаркет', 1244.99),
+      ('10 грудня 2024', 'Супермаркет', 100.00),
+      ('09 грудня 2024', 'Супермаркет', 26.98),
+    ];
+    return Scaffold(
+      appBar: AppBar(title: const Text('Еко-чеки')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'PAPER RECEIPTS ARE A THING OF THE PAST',
+            style: Theme.of(context)
+                .textTheme
+                .titleMedium
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Грудень 2024',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+          for (final r in receipts)
+            Card(
+              margin: const EdgeInsets.only(bottom: 12),
+              child: ListTile(
+                title: Text(r.$2),
+                subtitle: Text(r.$1),
+                trailing: Text('${r.$3.toStringAsFixed(2)} ₴'),
+                onTap: () {
+                  Navigator.of(context).push(
+                    MaterialPageRoute(
+                      builder: (_) => ReceiptDetailPage(
+                        date: r.$1,
+                        store: r.$2,
+                        total: r.$3,
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/demo/presentation/schedule_page.dart
+++ b/lib/features/demo/presentation/schedule_page.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class WorkSchedulePage extends StatelessWidget {
+  const WorkSchedulePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = const [
+      'Каса',
+      'Обідня перерва',
+      'Каса',
+      'Технічна перерва',
+      'Каса',
+      'Зміна завершена',
+    ];
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Робочий графік'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text(
+            'Серпень 2024',
+            style: Theme.of(context).textTheme.titleLarge,
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Відпрацьовано: 164 год 45 хв',
+            style: Theme.of(context).textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 16),
+          Card(
+            child: ListTile(
+              leading: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: const [Text('31'), Text('Сб')],
+              ),
+              title: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  for (final e in entries)
+                    Padding(
+                      padding: const EdgeInsets.symmetric(vertical: 2),
+                      child: Text(e),
+                    ),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -1,153 +1,90 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:peopleslab/common/widgets/search_field.dart';
-import 'package:peopleslab/app/bottom_nav.dart';
+import 'package:peopleslab/features/demo/presentation/applications_page.dart';
+import 'package:peopleslab/features/demo/presentation/gamification_page.dart';
+import 'package:peopleslab/features/demo/presentation/receipts_page.dart';
+import 'package:peopleslab/features/demo/presentation/schedule_page.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final categories = const [
-      'Burgers',
-      'Pizza',
-      'Sushi',
-      'Desserts',
-      'Coffee',
-      'Healthy',
-    ];
     return Scaffold(
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    AppSearchField(
-                      hintText: 'Search restaurants or dishes',
-                      onChanged: (_) {},
-                      onTap: () {
-                        // Open Search tab when tapping the search field
-                        ref.read(bottomNavIndexProvider.notifier).state = 1;
-                      },
-                      readOnly: true,
-                    ),
-                    const SizedBox(height: 12),
-                    SingleChildScrollView(
-                      scrollDirection: Axis.horizontal,
-                      child: Row(
-                        children: [
-                          for (final c in categories)
-                            Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: FilterChip(
-                                label: Text(c),
-                                onSelected: (_) {},
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                  ],
-                ),
-              ),
-            ),
-            SliverList.builder(
-              itemCount: 6,
-              itemBuilder: (context, index) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
-                    vertical: 8,
-                  ),
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12.0),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child: Container(
-                              width: 84,
-                              height: 84,
-                              color: colorScheme.primary.withValues(
-                                alpha: 0.08,
-                              ),
-                              child: Icon(
-                                Icons.restaurant_menu_rounded,
-                                color: colorScheme.primary,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Blue Bite • ${categories[index % categories.length]}',
-                                  style: theme.textTheme.titleMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(height: 6),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      Icons.star_rounded,
-                                      size: 18,
-                                      color: Colors.amber[600],
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text('4.${(index + 3) % 10} • 25-35 min'),
-                                    const SizedBox(width: 8),
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 4,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: colorScheme.primary.withValues(
-                                          alpha: 0.08,
-                                        ),
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      child: Text(
-                                        'Free delivery',
-                                        style: theme.textTheme.labelMedium
-                                            ?.copyWith(
-                                              color: colorScheme.primary,
-                                            ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 6),
-                                Text(
-                                  'Popular: Chicken bowl, Pepperoni pizza',
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: theme.colorScheme.onSurfaceVariant,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ],
-        ),
+      appBar: AppBar(title: const Text('PeoplesLab')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _FeatureCard(
+            title: 'Заяви',
+            subtitle: 'Подайте заяву та підпишіть її електронно',
+            icon: Icons.description_outlined,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const ApplicationsPage()),
+              );
+            },
+          ),
+          _FeatureCard(
+            title: 'Робочий графік',
+            subtitle: 'Зручний формат на кожен день',
+            icon: Icons.schedule_rounded,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const WorkSchedulePage()),
+              );
+            },
+          ),
+          _FeatureCard(
+            title: 'Еко-чеки',
+            subtitle: 'Усі чеки в екологічному форматі',
+            icon: Icons.receipt_long_rounded,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const ReceiptsPage()),
+              );
+            },
+          ),
+          _FeatureCard(
+            title: 'Добросусідство',
+            subtitle: 'Отримуйте нагороди за добрі справи',
+            icon: Icons.emoji_events_outlined,
+            onTap: () {
+              Navigator.of(context).push(
+                MaterialPageRoute(builder: (_) => const GamificationPage()),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeatureCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  const _FeatureCard({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = Theme.of(context).colorScheme.primary;
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      child: ListTile(
+        leading: Icon(icon, color: color),
+        title: Text(title),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.arrow_forward_ios_rounded, size: 16),
+        onTap: onTap,
       ),
     );
   }


### PR DESCRIPTION
## Summary
- build demo screens for applications, work schedule, eco receipts, and good-neighbor gamification
- wire home page to open new demo screens

## Testing
- `dart format lib/features/demo/presentation/*.dart lib/features/home/presentation/home_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0374c63a08331a04b36ddae57b817