### PR TITLE
feat: add demo feature pages

### DIFF
--- a/lib/features/applications/presentation/applications_page.dart
+++ b/lib/features/applications/presentation/applications_page.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+
+/// Сторінка із заявами працівників.
+class ApplicationsPage extends StatelessWidget {
+  const ApplicationsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = const [
+      ('Відпустка', 'Розглядається від 7 робочих днів'),
+      ('Лікарняний', 'Розглядається від 1-2 годин'),
+      ('Вихідний', 'Розглядається від 1-2 годин'),
+      ('Отримання компенсації', 'Розглядається від 1-2 годин'),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Заяви'),
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: items.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (context, index) {
+          final (title, subtitle) = items[index];
+          return Card(
+            child: ListTile(
+              title: Text(title),
+              subtitle: Text(subtitle),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () {},
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -1,152 +1,84 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:peopleslab/common/widgets/search_field.dart';
-import 'package:peopleslab/app/bottom_nav.dart';
+import 'package:peopleslab/features/applications/presentation/applications_page.dart';
+import 'package:peopleslab/features/schedule/presentation/work_schedule_page.dart';
+import 'package:peopleslab/features/receipts/presentation/receipts_page.dart';
+import 'package:peopleslab/features/neighborhood/presentation/neighborhood_page.dart';
 
-class HomePage extends ConsumerWidget {
+/// Головна сторінка з доступом до основних можливостей додатку.
+class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final categories = const [
-      'Burgers',
-      'Pizza',
-      'Sushi',
-      'Desserts',
-      'Coffee',
-      'Healthy',
-    ];
     return Scaffold(
-      body: SafeArea(
-        child: CustomScrollView(
-          slivers: [
-            SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    AppSearchField(
-                      hintText: 'Search restaurants or dishes',
-                      onChanged: (_) {},
-                      onTap: () {
-                        // Open Search tab when tapping the search field
-                        ref.read(bottomNavIndexProvider.notifier).state = 1;
-                      },
-                      readOnly: true,
-                    ),
-                    const SizedBox(height: 12),
-                    SingleChildScrollView(
-                      scrollDirection: Axis.horizontal,
-                      child: Row(
-                        children: [
-                          for (final c in categories)
-                            Padding(
-                              padding: const EdgeInsets.only(right: 8),
-                              child: FilterChip(
-                                label: Text(c),
-                                onSelected: (_) {},
-                              ),
-                            ),
-                        ],
-                      ),
-                    ),
-                    const SizedBox(height: 8),
-                  ],
-                ),
-              ),
-            ),
-            SliverList.builder(
-              itemCount: 6,
-              itemBuilder: (context, index) {
-                return Padding(
-                  padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
-                    vertical: 8,
-                  ),
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12.0),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child: Container(
-                              width: 84,
-                              height: 84,
-                              color: colorScheme.primary.withValues(
-                                alpha: 0.08,
-                              ),
-                              child: Icon(
-                                Icons.restaurant_menu_rounded,
-                                color: colorScheme.primary,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Blue Bite • ${categories[index % categories.length]}',
-                                  style: theme.textTheme.titleMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(height: 6),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      Icons.star_rounded,
-                                      size: 18,
-                                      color: Colors.amber[600],
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text('4.${(index + 3) % 10} • 25-35 min'),
-                                    const SizedBox(width: 8),
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 4,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: colorScheme.primary.withValues(
-                                          alpha: 0.08,
-                                        ),
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      child: Text(
-                                        'Free delivery',
-                                        style: theme.textTheme.labelMedium
-                                            ?.copyWith(
-                                              color: colorScheme.primary,
-                                            ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 6),
-                                Text(
-                                  'Popular: Chicken bowl, Pepperoni pizza',
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: theme.colorScheme.onSurfaceVariant,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          ],
+      appBar: AppBar(
+        title: const Text('Головна'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: const [
+          _FeatureCard(
+            title: 'Заяви',
+            subtitle: 'Подання заяв та електронний підпис',
+            icon: Icons.assignment_rounded,
+            page: ApplicationsPage(),
+          ),
+          SizedBox(height: 12),
+          _FeatureCard(
+            title: 'Робочий графік',
+            subtitle: 'Зручний формат із нагадуваннями',
+            icon: Icons.schedule_rounded,
+            page: WorkSchedulePage(),
+          ),
+          SizedBox(height: 12),
+          _FeatureCard(
+            title: 'Електронні чеки',
+            subtitle: 'Екоформат та зручна аналітика',
+            icon: Icons.receipt_long_rounded,
+            page: ReceiptsPage(),
+          ),
+          SizedBox(height: 12),
+          _FeatureCard(
+            title: 'Добросусідство',
+            subtitle: 'Підтримуйте проєкти та отримуйте нагороди',
+            icon: Icons.emoji_events_rounded,
+            page: NeighborhoodPage(),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FeatureCard extends StatelessWidget {
+  const _FeatureCard({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.page,
+  });
+
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final Widget page;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final color = theme.colorScheme.primary;
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: color.withOpacity(0.1),
+          child: Icon(icon, color: color),
+        ),
+        title: Text(title, style: theme.textTheme.titleMedium),
+        subtitle: Text(subtitle),
+        trailing: const Icon(Icons.chevron_right_rounded),
+        onTap: () => Navigator.of(context).push(
+          MaterialPageRoute(builder: (_) => page),
         ),
       ),
     );

--- a/lib/features/neighborhood/presentation/neighborhood_page.dart
+++ b/lib/features/neighborhood/presentation/neighborhood_page.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+
+/// Гейміфікація та підтримка проєктів у вашому районі.
+class NeighborhoodPage extends StatelessWidget {
+  const NeighborhoodPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Добросусідство'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Рівень добросусідства',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  LinearProgressIndicator(
+                    value: 0.6,
+                    minHeight: 8,
+                  ),
+                  const SizedBox(height: 8),
+                  Text('60% до наступної нагороди'),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.volunteer_activism_rounded),
+              title: const Text('Підтримати проект'),
+              subtitle:
+                  const Text('Долучіться до благоустрою парку у вашому районі'),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () {},
+            ),
+          ),
+          const SizedBox(height: 12),
+          Card(
+            child: ListTile(
+              leading: const Icon(Icons.emoji_events_rounded),
+              title: const Text('Ваші нагороди'),
+              subtitle: const Text('3 доступні нагороди'),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () {},
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/receipts/presentation/receipts_page.dart
+++ b/lib/features/receipts/presentation/receipts_page.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+
+/// Сторінка з електронними чеками та аналітикою.
+class ReceiptsPage extends StatelessWidget {
+  const ReceiptsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final items = const [
+      ('Супермаркет', 1244.99),
+      ('Булочний престиж', 98.00),
+      ('Книжковий рай', 256.88),
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Електронні чеки'),
+      ),
+      body: ListView.separated(
+        padding: const EdgeInsets.all(16),
+        itemCount: items.length,
+        separatorBuilder: (_, __) => const SizedBox(height: 12),
+        itemBuilder: (context, index) {
+          final (title, amount) = items[index];
+          return Card(
+            child: ListTile(
+              title: Text(title),
+              subtitle: const Text('Грудень 2024'),
+              trailing: Text(
+                amount.toStringAsFixed(2),
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              onTap: () {},
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/features/schedule/presentation/work_schedule_page.dart
+++ b/lib/features/schedule/presentation/work_schedule_page.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+/// Сторінка з відображенням робочого графіка.
+class WorkSchedulePage extends StatelessWidget {
+  const WorkSchedulePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final items = [
+      {
+        'day': '31',
+        'month': 'Сер',
+        'weekday': 'Сб',
+        'entries': ['Вихідний'],
+      },
+      {
+        'day': '1',
+        'month': 'Вер',
+        'weekday': 'Нд',
+        'entries': ['Вихідний'],
+      },
+      {
+        'day': '2',
+        'month': 'Вер',
+        'weekday': 'Пн',
+        'entries': [
+          'Каса 09:00-18:00',
+          'Обідня перерва 13:00-14:00',
+          'Каса 14:00-18:00',
+          'Технічна перерва 16:00-16:30',
+        ],
+      },
+    ];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Робочий графік'),
+      ),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: items.length,
+        itemBuilder: (context, index) {
+          final item = items[index];
+          return Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Card(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    SizedBox(
+                      width: 56,
+                      child: Column(
+                        children: [
+                          Text(
+                            item['day']!,
+                            style: theme.textTheme.headlineSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          Text(item['month']!),
+                          Text(item['weekday']!,
+                              style: theme.textTheme.bodySmall),
+                        ],
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          for (final e in item['entries'] as List<String>) ...[
+                            Text(e),
+                            const SizedBox(height: 4),
+                          ],
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- replace home page with feature cards for applications, schedule, receipts and neighborhood
- add ApplicationsPage, WorkSchedulePage, ReceiptsPage, NeighborhoodPage with sample UI and content

## Testing
- `dart format lib/features/home/presentation/home_page.dart lib/features/applications/presentation/applications_page.dart lib/features/schedule/presentation/work_schedule_page.dart lib/features/receipts/presentation/receipts_page.dart lib/features/neighborhood/presentation/neighborhood_page.dart` (fails: command not found)
- `flutter test` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c0374c63a08331a04b36ddae57b817