### PR TITLE
Redesign home screen for supplement campaigns

### DIFF
--- a/lib/core/theme/app_colors.dart
+++ b/lib/core/theme/app_colors.dart
@@ -4,9 +4,9 @@ import 'package:flutter/material.dart';
 class AppColors {
   AppColors._();
 
-  // Brand primary (blue) inspired by modern delivery apps, but blue.
-  static const Color primary = Color(0xFF2563EB); // Blue 600
-  static const Color primaryDark = Color(0xFF1D4ED8); // Blue 700
+  // Brand primary switched to a fresh green for research crowdfunding theme.
+  static const Color primary = Color(0xFF18B765); // Green accent
+  static const Color primaryDark = Color(0xFF139B54); // Darker green
 
   // Supporting colors (kept minimal; rely on ColorScheme for variants).
   static const Color success = Color(0xFF16A34A); // Green 600

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peopleslab/common/widgets/search_field.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
+import 'package:peopleslab/core/l10n/l10n_x.dart';
+import 'widgets/campaign_card.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -10,13 +12,35 @@ class HomePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final categories = const [
-      'Burgers',
-      'Pizza',
-      'Sushi',
-      'Desserts',
-      'Coffee',
-      'Healthy',
+    final l10n = context.l10n;
+    final categories = [
+      l10n.categoryImmunity,
+      l10n.categoryEnergy,
+      l10n.categorySleep,
+      l10n.categoryGutHealth,
+    ];
+    final campaigns = [
+      (
+        title: 'Vitamin D and Immune Response',
+        description:
+            'Help fund a trial studying high-dose vitamin D for immune health.',
+        raised: 7200.0,
+        goal: 10000.0,
+      ),
+      (
+        title: 'Rhodiola and Endurance',
+        description:
+            'Support research on Rhodiola rosea for energy and stress.',
+        raised: 4300.0,
+        goal: 7500.0,
+      ),
+      (
+        title: 'Magnesium for Better Sleep',
+        description:
+            'Backing a study on magnesium glycinate and sleep quality.',
+        raised: 2100.0,
+        goal: 5000.0,
+      ),
     ];
     return Scaffold(
       body: SafeArea(
@@ -29,7 +53,7 @@ class HomePage extends ConsumerWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     AppSearchField(
-                      hintText: 'Search restaurants or dishes',
+                      hintText: l10n.searchProjectsHint,
                       onChanged: (_) {},
                       onTap: () {
                         // Open Search tab when tapping the search field
@@ -59,89 +83,19 @@ class HomePage extends ConsumerWidget {
               ),
             ),
             SliverList.builder(
-              itemCount: 6,
+              itemCount: campaigns.length,
               itemBuilder: (context, index) {
+                final c = campaigns[index];
                 return Padding(
                   padding: const EdgeInsets.symmetric(
                     horizontal: 16.0,
                     vertical: 8,
                   ),
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12.0),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child: Container(
-                              width: 84,
-                              height: 84,
-                              color: colorScheme.primary.withValues(
-                                alpha: 0.08,
-                              ),
-                              child: Icon(
-                                Icons.restaurant_menu_rounded,
-                                color: colorScheme.primary,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Blue Bite • ${categories[index % categories.length]}',
-                                  style: theme.textTheme.titleMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(height: 6),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      Icons.star_rounded,
-                                      size: 18,
-                                      color: Colors.amber[600],
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text('4.${(index + 3) % 10} • 25-35 min'),
-                                    const SizedBox(width: 8),
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 4,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: colorScheme.primary.withValues(
-                                          alpha: 0.08,
-                                        ),
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      child: Text(
-                                        'Free delivery',
-                                        style: theme.textTheme.labelMedium
-                                            ?.copyWith(
-                                              color: colorScheme.primary,
-                                            ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 6),
-                                Text(
-                                  'Popular: Chicken bowl, Pepperoni pizza',
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: theme.colorScheme.onSurfaceVariant,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
+                  child: CampaignCard(
+                    title: c.title,
+                    description: c.description,
+                    raised: c.raised,
+                    goal: c.goal,
                   ),
                 );
               },

--- a/lib/features/home/presentation/widgets/campaign_card.dart
+++ b/lib/features/home/presentation/widgets/campaign_card.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:peopleslab/core/l10n/l10n_x.dart';
+
+/// Card displaying a single crowdfunding campaign.
+class CampaignCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final double raised;
+  final double goal;
+
+  const CampaignCard({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.raised,
+    required this.goal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final percent = (raised / goal).clamp(0, 1);
+    final currency = NumberFormat.simpleCurrency();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style:
+                  theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            Text(description),
+            const SizedBox(height: 12),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(value: percent, minHeight: 8),
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text('${currency.format(raised)} / ${currency.format(goal)}'),
+                FilledButton(
+                  onPressed: () {},
+                  child: Text(context.l10n.supportProject),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -56,6 +56,12 @@
   "validation_password_required": "Enter password",
   "validation_password_min": "Minimum 6 characters",
   "validation_code_required": "Code is required",
-  "validation_passwords_not_match": "Passwords do not match"
+  "validation_passwords_not_match": "Passwords do not match",
+  "searchProjectsHint": "Search research projects",
+  "supportProject": "Support project",
+  "categoryImmunity": "Immunity",
+  "categoryEnergy": "Energy",
+  "categorySleep": "Sleep",
+  "categoryGutHealth": "Gut health"
 }
 

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -369,6 +369,42 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Passwords do not match'**
   String get validation_passwords_not_match;
+
+  /// No description provided for @searchProjectsHint.
+  ///
+  /// In en, this message translates to:
+  /// **'Search research projects'**
+  String get searchProjectsHint;
+
+  /// No description provided for @supportProject.
+  ///
+  /// In en, this message translates to:
+  /// **'Support project'**
+  String get supportProject;
+
+  /// No description provided for @categoryImmunity.
+  ///
+  /// In en, this message translates to:
+  /// **'Immunity'**
+  String get categoryImmunity;
+
+  /// No description provided for @categoryEnergy.
+  ///
+  /// In en, this message translates to:
+  /// **'Energy'**
+  String get categoryEnergy;
+
+  /// No description provided for @categorySleep.
+  ///
+  /// In en, this message translates to:
+  /// **'Sleep'**
+  String get categorySleep;
+
+  /// No description provided for @categoryGutHealth.
+  ///
+  /// In en, this message translates to:
+  /// **'Gut health'**
+  String get categoryGutHealth;
 }
 
 class _AppLocalizationsDelegate

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -146,4 +146,22 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get validation_passwords_not_match => 'Passwords do not match';
+
+  @override
+  String get searchProjectsHint => 'Search research projects';
+
+  @override
+  String get supportProject => 'Support project';
+
+  @override
+  String get categoryImmunity => 'Immunity';
+
+  @override
+  String get categoryEnergy => 'Energy';
+
+  @override
+  String get categorySleep => 'Sleep';
+
+  @override
+  String get categoryGutHealth => 'Gut health';
 }

--- a/test/features/home/presentation/widgets/campaign_card_test.dart
+++ b/test/features/home/presentation/widgets/campaign_card_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peopleslab/l10n/app_localizations.dart';
+import 'package:peopleslab/features/home/presentation/widgets/campaign_card.dart';
+
+void main() {
+  testWidgets('renders campaign card with progress and button', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: const CampaignCard(
+          title: 'Test study',
+          description: 'Description',
+          raised: 50,
+          goal: 100,
+        ),
+      ),
+    );
+
+    expect(find.text('Test study'), findsOneWidget);
+    expect(find.byType(LinearProgressIndicator), findsOneWidget);
+    expect(find.textContaining('Support project'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- switch brand color to green to match crowdfunding theme
- add reusable `CampaignCard` widget with progress and support button
- rewrite home page to list sample supplement research campaigns and add localization strings

## Testing
- `make l10n-generate` *(fails: flutter: No such file or directory)*
- `dart format .` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03f8ea30c8331a9a2373210a8d1f5