### PR TITLE
Add donation success page

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -4,6 +4,7 @@ import 'package:peopleslab/core/router/app_router.dart';
 import 'package:peopleslab/l10n/app_localizations.dart';
 import 'package:peopleslab/core/l10n/l10n_x.dart';
 import 'package:peopleslab/core/theme/app_theme.dart';
+import 'package:peopleslab/core/theme/app_scroll.dart';
 import 'package:peopleslab/core/theme/theme_provider.dart';
 
 class App extends ConsumerWidget {
@@ -18,6 +19,7 @@ class App extends ConsumerWidget {
       theme: AppTheme.light(),
       darkTheme: AppTheme.dark(),
       themeMode: themeMode,
+      scrollBehavior: const AppScrollBehavior(),
       localizationsDelegates: AppLocalizations.localizationsDelegates,
       supportedLocales: AppLocalizations.supportedLocales,
       routerConfig: router,

--- a/lib/app/main_shell.dart
+++ b/lib/app/main_shell.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'dart:ui';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
 import 'package:peopleslab/features/home/presentation/home_page.dart';
 import 'package:peopleslab/features/search/presentation/search_page.dart';
 import 'package:peopleslab/features/auth/presentation/controllers/auth_controller.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peopleslab/core/router/app_router.dart';
 import 'package:peopleslab/core/theme/theme_provider.dart';
 import 'package:peopleslab/common/widgets/app_button.dart';
 import 'package:peopleslab/core/l10n/l10n_x.dart';
@@ -25,49 +28,67 @@ class MainShell extends ConsumerWidget {
           _ProfilePage(),
         ],
       ),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: index,
-        onDestinationSelected: (i) =>
-            ref.read(bottomNavIndexProvider.notifier).state = i,
-        // Height/indicator/colors are themed in AppTheme
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.home_outlined),
-            selectedIcon: Icon(Icons.home_rounded),
-            label: 'Головна',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.search_outlined),
-            selectedIcon: Icon(Icons.search_rounded),
-            label: 'Пошук',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.favorite_border_rounded),
-            selectedIcon: Icon(Icons.favorite_rounded),
-            label: 'Обране',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.person_outline_rounded),
-            selectedIcon: Icon(Icons.person_rounded),
-            label: 'Профіль',
-          ),
-        ],
-      ),
-    );
-  }
-}
-
-class _FavoritesPage extends StatelessWidget {
-  const _FavoritesPage();
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Center(
-          child: Text(
-            'Поки що порожньо',
-            style: Theme.of(context).textTheme.bodyLarge,
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(20),
+            child: BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 14, sigmaY: 14),
+              child: Container(
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surface.withOpacity(0.92),
+                  borderRadius: BorderRadius.circular(20),
+                  boxShadow: const [
+                    BoxShadow(
+                      color: Color.fromRGBO(15, 23, 42, 0.08),
+                      blurRadius: 24,
+                      offset: Offset(0, 8),
+                    ),
+                  ],
+                ),
+                child: NavigationBarTheme(
+                  data: NavigationBarThemeData(
+                    backgroundColor: Colors.transparent,
+                    indicatorColor: Theme.of(context).colorScheme.primary.withOpacity(0.10),
+                    indicatorShape: const StadiumBorder(),
+                    labelTextStyle: WidgetStatePropertyAll(
+                      Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  child: NavigationBar(
+                    height: 56,
+                    selectedIndex: index,
+                    labelBehavior: NavigationDestinationLabelBehavior.alwaysHide,
+                    onDestinationSelected: (i) =>
+                        ref.read(bottomNavIndexProvider.notifier).state = i,
+                    destinations: const [
+                      NavigationDestination(
+                        icon: Icon(Icons.home_outlined),
+                        selectedIcon: Icon(Icons.home_rounded),
+                        label: 'Головна',
+                      ),
+                      NavigationDestination(
+                        icon: Icon(Icons.search_outlined),
+                        selectedIcon: Icon(Icons.search_rounded),
+                        label: 'Пошук',
+                      ),
+                      NavigationDestination(
+                        icon: Icon(Icons.favorite_border_rounded),
+                        selectedIcon: Icon(Icons.favorite_rounded),
+                        label: 'Обране',
+                      ),
+                      NavigationDestination(
+                        icon: Icon(Icons.person_outline_rounded),
+                        selectedIcon: Icon(Icons.person_rounded),
+                        label: 'Профіль',
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
           ),
         ),
       ),
@@ -138,6 +159,16 @@ class _ProfilePage extends ConsumerWidget {
               },
             ),
             const SizedBox(height: 32),
+            Text('Гаманець', style: theme.textTheme.titleMedium),
+            const SizedBox(height: 8),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              leading: const Icon(Icons.account_balance_wallet_rounded),
+              title: const Text('Статистика по гаманцю'),
+              trailing: const Icon(Icons.chevron_right_rounded),
+              onTap: () => context.push(AppRoutes.wallet),
+            ),
+            const SizedBox(height: 24),
             AppButton.tonal(
               onPressed: () async {
                 await ref.read(authControllerProvider.notifier).signOut();
@@ -145,6 +176,24 @@ class _ProfilePage extends ConsumerWidget {
               label: s.action_sign_out,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+class _FavoritesPage extends StatelessWidget {
+  const _FavoritesPage();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: Text(
+            'Поки що порожньо',
+            style: Theme.of(context).textTheme.bodyLarge,
+          ),
         ),
       ),
     );

--- a/lib/common/widgets/app_button.dart
+++ b/lib/common/widgets/app_button.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/tap_scale.dart';
 
-enum _AppButtonVariant { primary, tonal, outlined, text }
+enum _AppButtonVariant { primary, outlined, ghost, tonal, destructive }
+
+enum AppButtonSize { large, medium, small }
 
 class AppButton extends StatelessWidget {
   final String label;
@@ -8,7 +11,9 @@ class AppButton extends StatelessWidget {
   final bool loading;
   final bool fullWidth;
   final IconData? leadingIcon;
+  final IconData? trailingIcon;
   final _AppButtonVariant _variant;
+  final AppButtonSize size;
 
   const AppButton._internal({
     required this.label,
@@ -17,106 +22,242 @@ class AppButton extends StatelessWidget {
     required this.fullWidth,
     required _AppButtonVariant variant,
     this.leadingIcon,
+    this.trailingIcon,
+    this.size = AppButtonSize.large,
     super.key,
   }) : _variant = variant;
 
+  // Primary (filled)
   const AppButton.primary({
     Key? key,
     required String label,
     VoidCallback? onPressed,
     bool loading = false,
     bool fullWidth = true,
+    AppButtonSize size = AppButtonSize.large,
     IconData? leadingIcon,
+    IconData? trailingIcon,
   }) : this._internal(
-         key: key,
-         label: label,
-         onPressed: onPressed,
-         loading: loading,
-         fullWidth: fullWidth,
-         variant: _AppButtonVariant.primary,
-         leadingIcon: leadingIcon,
-       );
+          key: key,
+          label: label,
+          onPressed: onPressed,
+          loading: loading,
+          fullWidth: fullWidth,
+          variant: _AppButtonVariant.primary,
+          leadingIcon: leadingIcon,
+          trailingIcon: trailingIcon,
+          size: size,
+        );
 
-  const AppButton.tonal({
-    Key? key,
-    required String label,
-    VoidCallback? onPressed,
-    bool loading = false,
-    bool fullWidth = true,
-    IconData? leadingIcon,
-  }) : this._internal(
-         key: key,
-         label: label,
-         onPressed: onPressed,
-         loading: loading,
-         fullWidth: fullWidth,
-         variant: _AppButtonVariant.tonal,
-         leadingIcon: leadingIcon,
-       );
-
+  // Secondary (outlined)
   const AppButton.outlined({
     Key? key,
     required String label,
     VoidCallback? onPressed,
     bool loading = false,
     bool fullWidth = true,
+    AppButtonSize size = AppButtonSize.large,
     IconData? leadingIcon,
+    IconData? trailingIcon,
   }) : this._internal(
-         key: key,
-         label: label,
-         onPressed: onPressed,
-         loading: loading,
-         fullWidth: fullWidth,
-         variant: _AppButtonVariant.outlined,
-         leadingIcon: leadingIcon,
-       );
+          key: key,
+          label: label,
+          onPressed: onPressed,
+          loading: loading,
+          fullWidth: fullWidth,
+          variant: _AppButtonVariant.outlined,
+          leadingIcon: leadingIcon,
+          trailingIcon: trailingIcon,
+          size: size,
+        );
 
+  // Tertiary (ghost)
   const AppButton.text({
     Key? key,
     required String label,
     VoidCallback? onPressed,
     bool loading = false,
     bool fullWidth = false,
+    AppButtonSize size = AppButtonSize.medium,
     IconData? leadingIcon,
+    IconData? trailingIcon,
   }) : this._internal(
-         key: key,
-         label: label,
-         onPressed: onPressed,
-         loading: loading,
-         fullWidth: fullWidth,
-         variant: _AppButtonVariant.text,
-         leadingIcon: leadingIcon,
-       );
+          key: key,
+          label: label,
+          onPressed: onPressed,
+          loading: loading,
+          fullWidth: fullWidth,
+          variant: _AppButtonVariant.ghost,
+          leadingIcon: leadingIcon,
+          trailingIcon: trailingIcon,
+          size: size,
+        );
+
+  // Tonal (kept for compatibility, used in Profile page for sign out etc.)
+  const AppButton.tonal({
+    Key? key,
+    required String label,
+    VoidCallback? onPressed,
+    bool loading = false,
+    bool fullWidth = true,
+    AppButtonSize size = AppButtonSize.large,
+    IconData? leadingIcon,
+    IconData? trailingIcon,
+  }) : this._internal(
+          key: key,
+          label: label,
+          onPressed: onPressed,
+          loading: loading,
+          fullWidth: fullWidth,
+          variant: _AppButtonVariant.tonal,
+          leadingIcon: leadingIcon,
+          trailingIcon: trailingIcon,
+          size: size,
+        );
+
+  // Destructive (red filled)
+  const AppButton.destructive({
+    Key? key,
+    required String label,
+    VoidCallback? onPressed,
+    bool loading = false,
+    bool fullWidth = true,
+    AppButtonSize size = AppButtonSize.large,
+    IconData? leadingIcon,
+    IconData? trailingIcon,
+  }) : this._internal(
+          key: key,
+          label: label,
+          onPressed: onPressed,
+          loading: loading,
+          fullWidth: fullWidth,
+          variant: _AppButtonVariant.destructive,
+          leadingIcon: leadingIcon,
+          trailingIcon: trailingIcon,
+          size: size,
+        );
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final child = _buildChild(colorScheme);
+    final scheme = Theme.of(context).colorScheme;
+    final child = _buildChild(scheme);
+    final style = _styleFor(context, scheme);
+
     final button = switch (_variant) {
       _AppButtonVariant.primary => FilledButton(
-        onPressed: _effectiveOnPressed,
-        child: child,
-      ),
+          onPressed: _effectiveOnPressed,
+          style: style,
+          child: child,
+        ),
       _AppButtonVariant.tonal => FilledButton.tonal(
-        onPressed: _effectiveOnPressed,
-        child: child,
-      ),
+          onPressed: _effectiveOnPressed,
+          style: style,
+          child: child,
+        ),
       _AppButtonVariant.outlined => OutlinedButton(
-        onPressed: _effectiveOnPressed,
-        child: child,
-      ),
-      _AppButtonVariant.text => TextButton(
-        onPressed: _effectiveOnPressed,
-        child: child,
-      ),
+          onPressed: _effectiveOnPressed,
+          style: style,
+          child: child,
+        ),
+      _AppButtonVariant.ghost => TextButton(
+          onPressed: _effectiveOnPressed,
+          style: style,
+          child: child,
+        ),
+      _AppButtonVariant.destructive => FilledButton(
+          onPressed: _effectiveOnPressed,
+          style: style,
+          child: child,
+        ),
     };
+
+    final scaled = TapScale(child: button);
     if (fullWidth) {
-      return SizedBox(width: double.infinity, child: button);
+      return SizedBox(width: double.infinity, child: scaled);
     }
-    return button;
+    return scaled;
   }
 
   VoidCallback? get _effectiveOnPressed => loading ? null : onPressed;
+
+  ButtonStyle _styleFor(BuildContext context, ColorScheme scheme) {
+    // Sizes: L=48 (16px x padding), M=40 (14px), S=36 (12px)
+    final (height, hPad) = switch (size) {
+      AppButtonSize.large => (48.0, 16.0),
+      AppButtonSize.medium => (40.0, 14.0),
+      AppButtonSize.small => (36.0, 12.0),
+    };
+
+    Color background;
+    Color foreground;
+    Color? borderColor;
+
+    switch (_variant) {
+      case _AppButtonVariant.primary:
+        background = scheme.primary;
+        foreground = scheme.onPrimary;
+        break;
+      case _AppButtonVariant.tonal:
+        background = scheme.secondaryContainer;
+        foreground = scheme.onSecondaryContainer;
+        break;
+      case _AppButtonVariant.outlined:
+        background = Colors.transparent;
+        foreground = scheme.onSurface;
+        borderColor = scheme.outlineVariant;
+        break;
+      case _AppButtonVariant.ghost:
+        background = Colors.transparent;
+        foreground = scheme.primary;
+        break;
+      case _AppButtonVariant.destructive:
+        background = scheme.error;
+        foreground = scheme.onError;
+        break;
+    }
+
+    final overlay = (Color base) => base.withOpacity(0.08);
+
+    return ButtonStyle(
+      minimumSize: WidgetStatePropertyAll(Size.fromHeight(height)),
+      padding: WidgetStatePropertyAll(
+        EdgeInsets.symmetric(horizontal: hPad),
+      ),
+      shape: WidgetStatePropertyAll(
+        RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      foregroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          return scheme.onSurfaceVariant; // neutral 500 → 300-ish
+        }
+        return foreground;
+      }),
+      backgroundColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.disabled)) {
+          if (_variant == _AppButtonVariant.primary ||
+              _variant == _AppButtonVariant.destructive ||
+              _variant == _AppButtonVariant.tonal) {
+            return scheme.surfaceVariant;
+          }
+          return Colors.transparent;
+        }
+        return background;
+      }),
+      side: WidgetStateProperty.resolveWith((states) {
+        if (_variant != _AppButtonVariant.outlined) return null;
+        final color = states.contains(WidgetState.disabled)
+            ? scheme.outlineVariant
+            : borderColor ?? scheme.outlineVariant;
+        return BorderSide(color: color);
+      }),
+      overlayColor: WidgetStateProperty.resolveWith((states) {
+        if (states.contains(WidgetState.pressed)) {
+          return overlay(Colors.black);
+        }
+        return null;
+      }),
+    );
+  }
 
   Widget _buildChild(ColorScheme scheme) {
     if (loading) {
@@ -124,11 +265,12 @@ class AppButton extends StatelessWidget {
         _AppButtonVariant.primary => scheme.onPrimary,
         _AppButtonVariant.tonal => scheme.onSecondaryContainer,
         _AppButtonVariant.outlined => scheme.primary,
-        _AppButtonVariant.text => scheme.primary,
+        _AppButtonVariant.ghost => scheme.primary,
+        _AppButtonVariant.destructive => scheme.onError,
       };
       return SizedBox(
-        width: 18,
-        height: 18,
+        width: 16,
+        height: 16,
         child: CircularProgressIndicator(
           strokeWidth: 2,
           valueColor: AlwaysStoppedAnimation(spinnerColor),
@@ -137,14 +279,18 @@ class AppButton extends StatelessWidget {
     }
 
     final labelWidget = Text(label);
-    if (leadingIcon == null) return labelWidget;
+    final leading = leadingIcon != null ? Icon(leadingIcon, size: 20) : null;
+    final trailing = trailingIcon != null ? Icon(trailingIcon, size: 20) : null;
+
+    if (leading == null && trailing == null) return labelWidget;
+
     return Row(
       mainAxisSize: MainAxisSize.min,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Icon(leadingIcon, size: 20),
-        const SizedBox(width: 8),
+        if (leading != null) ...[leading, const SizedBox(width: 8)],
         labelWidget,
+        if (trailing != null) ...[const SizedBox(width: 8), trailing],
       ],
     );
   }

--- a/lib/common/widgets/app_checkbox.dart
+++ b/lib/common/widgets/app_checkbox.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class AppCheckbox extends StatelessWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final bool disabled;
+  final String? label;
+  final EdgeInsetsGeometry? padding;
+
+  const AppCheckbox({
+    super.key,
+    required this.value,
+    this.onChanged,
+    this.disabled = false,
+    this.label,
+    this.padding,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final canTap = onChanged != null && !disabled;
+    final box = _Box(value: value, disabled: disabled);
+    final content = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        box,
+        if (label != null) ...[
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label!,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: disabled
+                        ? Theme.of(context)
+                            .colorScheme
+                            .onSurfaceVariant
+                            .withOpacity(0.7)
+                        : null,
+                  ),
+            ),
+          ),
+        ],
+      ],
+    );
+
+    return Padding(
+      padding: padding ?? EdgeInsets.zero,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(6),
+        onTap: canTap ? () => onChanged!(!value) : null,
+        child: content,
+      ),
+    );
+  }
+}
+
+class _Box extends StatelessWidget {
+  final bool value;
+  final bool disabled;
+  const _Box({required this.value, required this.disabled});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final bg = value
+        ? scheme.primary
+        : Colors.transparent;
+    final border = value
+        ? scheme.primary
+        : AppPalette.n300;
+
+    return AnimatedContainer(
+      duration: AppDurations.medium,
+      curve: AppCurves.standard,
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        color: disabled ? scheme.surfaceVariant : bg,
+        borderRadius: BorderRadius.circular(4),
+        border: Border.all(
+          color: disabled ? scheme.outlineVariant : border,
+          width: 1.5,
+        ),
+      ),
+      child: value
+          ? const Icon(
+              Icons.check_rounded,
+              size: 14,
+              color: Colors.white,
+            )
+          : null,
+    );
+  }
+}
+

--- a/lib/common/widgets/app_circular_progress.dart
+++ b/lib/common/widgets/app_circular_progress.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class AppCircularProgress extends StatelessWidget {
+  final double value; // 0..1
+  final double diameter; // outer diameter
+  final double thickness; // stroke width
+  final Widget? center;
+  final Color? color;
+  final Color? backgroundColor;
+
+  const AppCircularProgress({
+    super.key,
+    required this.value,
+    this.diameter = 72,
+    this.thickness = 8,
+    this.center,
+    this.color,
+    this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final bg = backgroundColor ?? AppPalette.n200;
+    final fill = color ?? scheme.primary;
+    final pct = value.clamp(0.0, 1.0);
+
+    return SizedBox(
+      width: diameter,
+      height: diameter,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          CircularProgressIndicator(
+            value: 1,
+            strokeWidth: thickness,
+            valueColor: AlwaysStoppedAnimation(bg),
+            backgroundColor: Colors.transparent,
+          ),
+          TweenAnimationBuilder<double>(
+            tween: Tween(begin: 0, end: pct),
+            duration: AppDurations.medium,
+            curve: AppCurves.standard,
+            builder: (context, v, _) => CircularProgressIndicator(
+              value: v,
+              strokeWidth: thickness,
+              valueColor: AlwaysStoppedAnimation(fill),
+              backgroundColor: Colors.transparent,
+            ),
+          ),
+          if (center != null) center!,
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/app_filter_chip.dart
+++ b/lib/common/widgets/app_filter_chip.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class AppFilterChip extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback? onPressed;
+  final IconData? icon;
+
+  const AppFilterChip({
+    super.key,
+    required this.label,
+    required this.selected,
+    this.onPressed,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final bg = selected ? AppPalette.mint : scheme.surface;
+    final textColor = selected ? AppPalette.n700 : scheme.onSurface;
+    final border = scheme.outlineVariant;
+
+    final child = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (icon != null) ...[
+          Icon(icon, size: 18, color: textColor),
+          const SizedBox(width: 6),
+        ],
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: AppTextScale.secondary,
+            height: 20 / AppTextScale.secondary,
+            color: textColor,
+          ),
+        ),
+      ],
+    );
+
+    return AnimatedContainer(
+      duration: AppDurations.color,
+      curve: AppCurves.standard,
+      decoration: ShapeDecoration(
+        color: bg,
+        shape: StadiumBorder(side: BorderSide(color: border)),
+      ),
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: onPressed,
+          customBorder: const StadiumBorder(),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(minHeight: 32),
+              child: Center(child: child),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/app_linear_progress.dart
+++ b/lib/common/widgets/app_linear_progress.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class AppLinearProgress extends StatelessWidget {
+  final double value; // 0..1
+  final String? label; // optional text like "63%"
+  final Color? color;
+  final Color? backgroundColor;
+
+  const AppLinearProgress({
+    super.key,
+    required this.value,
+    this.label,
+    this.color,
+    this.backgroundColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final bg = backgroundColor ?? AppPalette.n200;
+    final fill = color ?? scheme.primary;
+    final pct = value.clamp(0.0, 1.0);
+
+    return Row(
+      children: [
+        Expanded(
+          child: ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: SizedBox(
+              height: 8,
+              child: Stack(
+                children: [
+                  Container(color: bg),
+                  AnimatedFractionallySizedBox(
+                    duration: AppDurations.medium,
+                    curve: AppCurves.standard,
+                    widthFactor: pct,
+                    child: Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.centerLeft,
+                          end: Alignment.centerRight,
+                          colors: [
+                            scheme.primary,
+                            AppPalette.primary500,
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        if (label != null) ...[
+          const SizedBox(width: 8),
+          Text(
+            label!,
+            style: TextStyle(
+              fontSize: AppTextScale.secondary,
+              height: 20 / AppTextScale.secondary,
+              color: scheme.onSurface,
+            ),
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/common/widgets/app_radio.dart
+++ b/lib/common/widgets/app_radio.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class AppRadio<T> extends StatelessWidget {
+  final T value;
+  final T? groupValue;
+  final ValueChanged<T>? onChanged;
+  final String? label;
+  final bool disabled;
+  final EdgeInsetsGeometry? padding;
+
+  const AppRadio({
+    super.key,
+    required this.value,
+    required this.groupValue,
+    this.onChanged,
+    this.label,
+    this.disabled = false,
+    this.padding,
+  });
+
+  bool get selected => value == groupValue;
+
+  @override
+  Widget build(BuildContext context) {
+    final canTap = onChanged != null && !disabled;
+    final dot = _Dot(selected: selected, disabled: disabled);
+    final content = Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        dot,
+        if (label != null) ...[
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              label!,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                    color: disabled
+                        ? Theme.of(context)
+                            .colorScheme
+                            .onSurfaceVariant
+                            .withOpacity(0.7)
+                        : null,
+                  ),
+            ),
+          ),
+        ],
+      ],
+    );
+
+    return Padding(
+      padding: padding ?? EdgeInsets.zero,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: canTap ? () => onChanged!(value) : null,
+        child: content,
+      ),
+    );
+  }
+}
+
+class _Dot extends StatelessWidget {
+  final bool selected;
+  final bool disabled;
+  const _Dot({required this.selected, required this.disabled});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final fill = selected ? scheme.primary : Colors.transparent;
+    final border = selected ? scheme.primary : AppPalette.n300;
+
+    return AnimatedContainer(
+      duration: AppDurations.medium,
+      curve: AppCurves.standard,
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        color: disabled ? scheme.surfaceVariant : fill,
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: disabled ? scheme.outlineVariant : border,
+          width: 1.5,
+        ),
+      ),
+      child: selected
+          ? Center(
+              child: Container(
+                width: 10,
+                height: 10,
+                decoration: const BoxDecoration(
+                  color: Colors.white,
+                  shape: BoxShape.circle,
+                ),
+              ),
+            )
+          : null,
+    );
+  }
+}
+

--- a/lib/common/widgets/app_text_field.dart
+++ b/lib/common/widgets/app_text_field.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+enum AppTextFieldVariant { outline, filled, multiline }
+
+class AppTextField extends StatelessWidget {
+  final TextEditingController? controller;
+  final FocusNode? focusNode;
+  final String? labelText;
+  final String? hintText;
+  final String? helperText;
+  final String? errorText;
+  final bool success;
+  final TextInputType? keyboardType;
+  final bool obscureText;
+  final int? maxLines;
+  final Widget? prefixIcon;
+  final Widget? suffixIcon;
+  final AppTextFieldVariant variant;
+  final ValueChanged<String>? onChanged;
+  final FormFieldValidator<String>? validator;
+
+  const AppTextField({
+    super.key,
+    this.controller,
+    this.focusNode,
+    this.labelText,
+    this.hintText,
+    this.helperText,
+    this.errorText,
+    this.success = false,
+    this.keyboardType,
+    this.obscureText = false,
+    this.maxLines,
+    this.prefixIcon,
+    this.suffixIcon,
+    this.variant = AppTextFieldVariant.outline,
+    this.onChanged,
+    this.validator,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+
+    final outline = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(AppRadii.control),
+      borderSide: const BorderSide(color: AppPalette.n200),
+    );
+
+    final focused = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(AppRadii.control),
+      borderSide: const BorderSide(color: AppPalette.primary600, width: 1.5),
+    );
+
+    final successBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(AppRadii.control),
+      borderSide: const BorderSide(color: AppPalette.success, width: 1.5),
+    );
+
+    final errorBorder = OutlineInputBorder(
+      borderRadius: BorderRadius.circular(AppRadii.control),
+      borderSide: const BorderSide(color: AppPalette.danger, width: 1.5),
+    );
+
+    final filled = variant == AppTextFieldVariant.filled ||
+        variant == AppTextFieldVariant.multiline;
+    final lines = switch (variant) {
+      AppTextFieldVariant.multiline => (min: 1, max: 4),
+      _ => (min: 1, max: 1),
+    };
+
+    final decoration = InputDecoration(
+      labelText: labelText,
+      hintText: hintText,
+      helperText: helperText,
+      errorText: errorText,
+      prefixIcon: prefixIcon,
+      suffixIcon: suffixIcon,
+      filled: filled,
+      fillColor: filled ? AppPalette.n100 : null,
+      border: outline,
+      enabledBorder: outline,
+      focusedBorder: success ? successBorder : focused,
+      errorBorder: errorBorder,
+      focusedErrorBorder: errorBorder,
+      helperStyle: TextStyle(
+        fontSize: AppTextScale.caption,
+        height: 16 / AppTextScale.caption,
+        color: scheme.onSurfaceVariant,
+      ),
+      errorStyle: TextStyle(
+        fontSize: AppTextScale.caption,
+        height: 16 / AppTextScale.caption,
+        color: scheme.error,
+      ),
+      contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+    );
+
+    return TextFormField(
+      controller: controller,
+      focusNode: focusNode,
+      onChanged: onChanged,
+      validator: validator,
+      keyboardType: keyboardType,
+      obscureText: obscureText,
+      minLines: maxLines ?? lines.min,
+      maxLines: maxLines ?? lines.max,
+      decoration: decoration,
+    );
+  }
+}
+

--- a/lib/common/widgets/app_toggle.dart
+++ b/lib/common/widgets/app_toggle.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class AppToggle extends StatefulWidget {
+  final bool value;
+  final ValueChanged<bool>? onChanged;
+  final bool showIcons;
+  final String? semanticsLabel;
+
+  const AppToggle({
+    super.key,
+    required this.value,
+    this.onChanged,
+    this.showIcons = false,
+    this.semanticsLabel,
+  });
+
+  @override
+  State<AppToggle> createState() => _AppToggleState();
+}
+
+class _AppToggleState extends State<AppToggle> {
+  bool _focused = false;
+
+  void _toggle() {
+    if (widget.onChanged != null) widget.onChanged!(!widget.value);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final on = widget.value;
+    final trackColor = on ? AppPalette.primary600 : AppPalette.n300;
+
+    return Semantics(
+      label: widget.semanticsLabel,
+      toggled: on,
+      button: true,
+      child: Focus(
+        onFocusChange: (f) => setState(() => _focused = f),
+        child: GestureDetector(
+          onTap: _toggle,
+          behavior: HitTestBehavior.opaque,
+          child: SizedBox(
+            width: 52,
+            height: 32,
+            child: Stack(
+              alignment: Alignment.center,
+              children: [
+                AnimatedContainer(
+                  duration: AppDurations.medium,
+                  curve: AppCurves.standard,
+                  width: 52,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: trackColor,
+                    borderRadius: BorderRadius.circular(16),
+                    boxShadow: _focused ? AppShadows.elevation1 : null,
+                  ),
+                ),
+                AnimatedAlign(
+                  duration: AppDurations.medium,
+                  curve: AppCurves.standard,
+                  alignment: on ? Alignment.centerRight : Alignment.centerLeft,
+                  child: Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 2),
+                    child: Container(
+                      width: 28,
+                      height: 28,
+                      decoration: const BoxDecoration(
+                        color: Colors.white,
+                        shape: BoxShape.circle,
+                      ),
+                      child: widget.showIcons
+                          ? AnimatedSwitcher(
+                              duration: AppDurations.color,
+                              child: on
+                                  ? const Icon(Icons.check_rounded,
+                                      key: ValueKey('on'),
+                                      size: 16,
+                                      color: AppPalette.primary600)
+                                  : const Icon(Icons.close_rounded,
+                                      key: ValueKey('off'),
+                                      size: 16,
+                                      color: AppPalette.n500),
+                            )
+                          : null,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/hero_section.dart
+++ b/lib/common/widgets/hero_section.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class HeroSection extends StatelessWidget {
+  final Widget title;
+  final Widget? subtitle;
+  final List<Widget> chips;
+  final EdgeInsetsGeometry padding;
+
+  const HeroSection({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.chips = const [],
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isDark = theme.brightness == Brightness.dark;
+    final gradient = LinearGradient(
+      begin: Alignment.topLeft,
+      end: Alignment.bottomRight,
+      colors: isDark
+          ? [
+              AppPalette.cardDark,
+              const Color(0xFF0E1524),
+            ]
+          : [
+              AppPalette.sky,
+              Colors.white,
+            ],
+    );
+
+    return Container(
+      decoration: BoxDecoration(
+        gradient: gradient,
+        borderRadius: BorderRadius.circular(AppRadii.card),
+        boxShadow: AppShadows.elevation1,
+        border: isDark ? Border.all(color: AppPalette.borderDark) : null,
+      ),
+      padding: padding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          title,
+          if (subtitle != null) ...[
+            const SizedBox(height: 6),
+            DefaultTextStyle.merge(
+              style: theme.textTheme.bodyLarge!,
+              child: subtitle!,
+            ),
+          ],
+          if (chips.isNotEmpty) ...[
+            const SizedBox(height: 10),
+            Wrap(spacing: 8, runSpacing: 8, children: chips),
+          ],
+          const SizedBox(height: 8),
+          Row(
+            children: const [
+              Icon(Icons.info_outline_rounded, size: 16, color: Colors.black54),
+              SizedBox(width: 6),
+              Flexible(
+                child: Text(
+                  'Додаток не надає медичних порад',
+                  style: TextStyle(fontSize: 12, height: 1.2, color: Color(0xFF334155)),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/meta_pill.dart
+++ b/lib/common/widgets/meta_pill.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class MetaPill extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final Color? color;
+  const MetaPill({super.key, required this.icon, required this.label, this.color});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final fg = color ?? scheme.onSurface;
+    final bg = AppPalette.sky;
+    return Container(
+      decoration: ShapeDecoration(
+        color: bg,
+        shape: const StadiumBorder(),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: fg),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              color: fg,
+              fontSize: AppTextScale.caption,
+              height: 16 / AppTextScale.caption,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/micro_badge.dart
+++ b/lib/common/widgets/micro_badge.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+enum BadgeTone { neutral, success, info }
+
+class MicroBadge extends StatelessWidget {
+  final String text;
+  final BadgeTone tone;
+  final IconData? icon;
+
+  const MicroBadge({
+    super.key,
+    required this.text,
+    this.tone = BadgeTone.neutral,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final (bg, fg) = switch (tone) {
+      BadgeTone.success => (AppPalette.mint, AppPalette.primary700),
+      BadgeTone.info => (AppPalette.lavender, AppPalette.n700),
+      BadgeTone.neutral => (AppPalette.n100, AppPalette.n700),
+    };
+
+    return Container(
+      height: 18,
+      padding: const EdgeInsets.symmetric(horizontal: 8),
+      decoration: ShapeDecoration(
+        color: bg,
+        shape: const StadiumBorder(),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 12, color: fg),
+            const SizedBox(width: 4),
+          ],
+          Text(
+            text,
+            style: TextStyle(
+              color: fg,
+              fontSize: AppTextScale.caption,
+              height: 16 / AppTextScale.caption,
+              fontWeight: FontWeight.w600,
+              letterSpacing: 0.1,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/project_card_skeleton.dart
+++ b/lib/common/widgets/project_card_skeleton.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/shimmer_box.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class ProjectCardSkeleton extends StatelessWidget {
+  const ProjectCardSkeleton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Container(
+      decoration: BoxDecoration(
+        color: scheme.surface,
+        borderRadius: BorderRadius.circular(AppRadii.card),
+        boxShadow: AppShadows.elevation1,
+      ),
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: const [
+          ShimmerBox(height: 18, width: 180),
+          SizedBox(height: 8),
+          ShimmerBox(height: 14, width: 240),
+          SizedBox(height: 12),
+          ShimmerBox(height: 8),
+          SizedBox(height: 8),
+          ShimmerBox(height: 12, width: 160),
+          SizedBox(height: 12),
+          Row(
+            children: [
+              ShimmerBox(height: 26, width: 72, borderRadius: BorderRadius.all(Radius.circular(999))),
+              SizedBox(width: 8),
+              ShimmerBox(height: 26, width: 64, borderRadius: BorderRadius.all(Radius.circular(999))),
+              SizedBox(width: 8),
+              ShimmerBox(height: 26, width: 60, borderRadius: BorderRadius.all(Radius.circular(999))),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/project_preview_card.dart
+++ b/lib/common/widgets/project_preview_card.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/app_linear_progress.dart';
+import 'package:peopleslab/common/widgets/app_filter_chip.dart';
+import 'package:peopleslab/common/widgets/micro_badge.dart';
+import 'package:peopleslab/common/widgets/risk_tag.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+import 'package:peopleslab/common/widgets/tap_scale.dart';
+import 'package:peopleslab/common/widgets/meta_pill.dart';
+import 'dart:async';
+
+class ProjectCardData {
+  final String title; // H3
+  final String subtitle; // Body
+  final double collected; // in currency units
+  final double target; // in currency units
+  final String status; // e.g. "🧪 Набір"
+  final String design; // e.g. "RCT"
+  final String term; // e.g. "3 міс"
+  final RiskLevel risk;
+  final bool ethicalBoard;
+  final DateTime? endsAt;
+
+  const ProjectCardData({
+    required this.title,
+    required this.subtitle,
+    required this.collected,
+    required this.target,
+    required this.status,
+    required this.design,
+    required this.term,
+    required this.risk,
+    this.ethicalBoard = false,
+    this.endsAt,
+  });
+
+  double get progress => target <= 0 ? 0 : (collected / target).clamp(0, 1);
+}
+
+enum ProjectCardActionKind { follow, support }
+
+class ProjectPreviewCard extends StatefulWidget {
+  final ProjectCardData data;
+  final VoidCallback? onTap;
+  final VoidCallback? onAction; // ignored (support pill removed)
+  final ProjectCardActionKind actionKind; // ignored
+
+  const ProjectPreviewCard({
+    super.key,
+    required this.data,
+    this.onTap,
+    this.onAction,
+    this.actionKind = ProjectCardActionKind.support,
+  });
+
+  @override
+  State<ProjectPreviewCard> createState() => _ProjectPreviewCardState();
+}
+
+class _ProjectPreviewCardState extends State<ProjectPreviewCard> {
+  bool _pressed = false;
+  Timer? _timer;
+  Duration _left = Duration.zero;
+
+  @override
+  void initState() {
+    super.initState();
+    _computeLeft();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) => _computeLeft());
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _computeLeft() {
+    final end = widget.data.endsAt;
+    if (end == null) return;
+    final now = DateTime.now();
+    setState(() => _left = end.isAfter(now) ? end.difference(now) : Duration.zero);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final d = widget.data;
+    final scheme = Theme.of(context).colorScheme;
+    final pct = (d.progress * 100).round();
+
+    return GestureDetector(
+      onTapDown: (_) => setState(() => _pressed = true),
+      onTapCancel: () => setState(() => _pressed = false),
+      onTapUp: (_) => setState(() => _pressed = false),
+      onTap: widget.onTap,
+      behavior: HitTestBehavior.opaque,
+      child: AnimatedScale(
+        duration: AppDurations.color,
+        scale: _pressed ? 0.98 : 1,
+        curve: AppCurves.standard,
+        child: Container(
+          decoration: BoxDecoration(
+            color: scheme.surface,
+            borderRadius: BorderRadius.circular(AppRadii.card),
+            boxShadow: AppShadows.elevation1,
+          ),
+          clipBehavior: Clip.antiAlias,
+          child: Stack(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    // Top: title, subtitle, badges
+                    Text(
+                      d.title,
+                      style: Theme.of(context).textTheme.headlineSmall,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      d.subtitle,
+                      style: Theme.of(context).textTheme.bodyLarge,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        RiskTag(level: d.risk, dense: true),
+                        if (d.ethicalBoard)
+                          const MicroBadge(
+                            text: 'Етична рада',
+                            tone: BadgeTone.success,
+                            icon: Icons.verified_outlined,
+                          ),
+                      ],
+                    ),
+
+                    const SizedBox(height: 10),
+                    // Middle: meta pills
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        MetaPill(icon: Icons.science_rounded, label: d.status),
+                        MetaPill(icon: Icons.biotech_rounded, label: d.design),
+                        MetaPill(icon: Icons.calendar_today_rounded, label: d.term),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    // Bottom: progress and time left
+                    AppLinearProgress(value: d.progress),
+                    const SizedBox(height: 6),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '₴${_fmt(d.collected)} з ₴${_fmt(d.target)}',
+                          style: Theme.of(context).textTheme.bodyMedium,
+                        ),
+                        if (widget.data.endsAt != null)
+                          Row(
+                            children: [
+                              const Icon(Icons.timer_rounded, size: 16, color: Color(0xFF64748B)),
+                              const SizedBox(width: 4),
+                              Text(_formatLeft(), style: Theme.of(context).textTheme.bodySmall),
+                            ],
+                          ),
+                      ],
+                    ),
+                    const SizedBox(height: 2),
+                  ],
+                ),
+              ),
+              // Support action pill removed per request
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _formatLeft() {
+    final d = _left.inDays;
+    final h = _left.inHours % 24;
+    final m = _left.inMinutes % 60;
+    if (_left == Duration.zero) return 'завершено';
+    if (d > 0) return '$d д $h г';
+    if (h > 0) return '$h г $m хв';
+    return '$m хв';
+  }
+
+  String _fmt(double v) {
+    // Simple thousands with spaces: 123456 -> 123 456
+    final s = v.toStringAsFixed(0);
+    final buf = StringBuffer();
+    for (int i = 0; i < s.length; i++) {
+      final idx = s.length - i - 1;
+      final ch = s[idx];
+      buf.write(ch);
+      if (i % 3 == 2 && idx != 0) buf.write(' ');
+    }
+    return buf.toString().split('').reversed.join();
+  }
+}
+
+class _MiniAction extends StatelessWidget {
+  final ProjectCardActionKind kind;
+  final VoidCallback? onPressed;
+
+  const _MiniAction({required this.kind, this.onPressed});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final (bg, border, fg, icon) = switch (kind) {
+      ProjectCardActionKind.follow => (
+          scheme.surface,
+          scheme.outlineVariant,
+          scheme.primary,
+          Icons.favorite_border_rounded,
+        ),
+      ProjectCardActionKind.support => (
+          scheme.primary,
+          Colors.transparent,
+          scheme.onPrimary,
+          Icons.add_rounded,
+        ),
+    };
+    return DecoratedBox(
+      decoration: ShapeDecoration(
+        color: bg,
+        shape: const StadiumBorder(),
+        shadows: kind == ProjectCardActionKind.support ? AppShadows.elevation2 : AppShadows.elevation1,
+      ),
+      child: Material(
+        color: Colors.transparent,
+        shape: const StadiumBorder(),
+        child: InkWell(
+          customBorder: const StadiumBorder(),
+          onTap: onPressed,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(icon, color: fg, size: 18),
+                if (kind == ProjectCardActionKind.support) ...[
+                  const SizedBox(width: 6),
+                  Text('Підтримати', style: TextStyle(color: fg, fontWeight: FontWeight.w600)),
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/receipt_card.dart
+++ b/lib/common/widgets/receipt_card.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:peopleslab/common/widgets/micro_badge.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class ReceiptCard extends StatelessWidget {
+  final String projectTitle;
+  final double amount;
+  final DateTime dateTime;
+  final String transactionId;
+  final String frequency; // once/monthly
+  final String method; // card/apple/gpay
+  final VoidCallback? onTap;
+
+  const ReceiptCard({
+    super.key,
+    required this.projectTitle,
+    required this.amount,
+    required this.dateTime,
+    required this.transactionId,
+    required this.frequency,
+    required this.method,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final f = NumberFormat.currency(locale: 'uk_UA', symbol: '₴', decimalDigits: 2);
+    final d = DateFormat('dd.MM.yyyy, HH:mm');
+    final scheme = Theme.of(context).colorScheme;
+    final icon = switch (method) {
+      'apple' => Icons.phone_iphone_rounded,
+      'gpay' => Icons.android_rounded,
+      _ => Icons.credit_card_rounded,
+    };
+
+    return Material(
+      color: AppPalette.sand,
+      elevation: 0,
+      borderRadius: BorderRadius.circular(AppRadii.card),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadii.card),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: scheme.surface,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(icon),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: Text(
+                            projectTitle,
+                            style: Theme.of(context).textTheme.titleMedium,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                        ),
+                        Text(
+                          f.format(amount),
+                          style: Theme.of(context)
+                              .textTheme
+                              .titleMedium
+                              ?.copyWith(fontWeight: FontWeight.w700),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 4),
+                    Row(
+                      children: [
+                        Text('${d.format(dateTime)} · ID $transactionId'),
+                        const SizedBox(width: 8),
+                        MicroBadge(
+                          text: frequency == 'monthly' ? 'Щомісяця' : 'Разово',
+                          tone: frequency == 'monthly'
+                              ? BadgeTone.info
+                              : BadgeTone.neutral,
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/risk_tag.dart
+++ b/lib/common/widgets/risk_tag.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+enum RiskLevel { low, mid, high }
+
+class RiskTag extends StatelessWidget {
+  final RiskLevel level;
+  final bool dense;
+
+  const RiskTag({super.key, required this.level, this.dense = false});
+
+  @override
+  Widget build(BuildContext context) {
+    final (bg, fg, text) = switch (level) {
+      RiskLevel.low => (
+          AppPalette.mint,
+          AppPalette.primary700,
+          'Low risk',
+        ),
+      RiskLevel.mid => (
+          const Color(0xFFFFF2CC),
+          const Color(0xFF9A6B00),
+          'Mid risk',
+        ),
+      RiskLevel.high => (
+          const Color(0xFFFFE3D2),
+          const Color(0xFF9A3C00),
+          'High risk',
+        ),
+    };
+
+    final height = dense ? 22.0 : 26.0;
+    final radius = AppRadii.pill;
+
+    return Container(
+      decoration: ShapeDecoration(
+        color: bg,
+        shape: StadiumBorder(side: BorderSide(color: bg.withOpacity(0.6))),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 10),
+      height: height,
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.shield_outlined, size: dense ? 14 : 16, color: fg),
+          const SizedBox(width: 6),
+          Text(
+            text,
+            style: TextStyle(
+              color: fg,
+              fontSize: AppTextScale.caption,
+              height: 16 / AppTextScale.caption,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/common/widgets/shimmer_box.dart
+++ b/lib/common/widgets/shimmer_box.dart
@@ -1,0 +1,84 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+
+class ShimmerBox extends StatefulWidget {
+  final double height;
+  final double? width;
+  final BorderRadius borderRadius;
+
+  const ShimmerBox({
+    super.key,
+    required this.height,
+    this.width,
+    this.borderRadius = const BorderRadius.all(Radius.circular(8)),
+  });
+
+  @override
+  State<ShimmerBox> createState() => _ShimmerBoxState();
+}
+
+class _ShimmerBoxState extends State<ShimmerBox>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _ctrl;
+
+  @override
+  void initState() {
+    super.initState();
+    _ctrl = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1200),
+    )..repeat();
+  }
+
+  @override
+  void dispose() {
+    _ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final base = Theme.of(context).colorScheme.surfaceVariant;
+    return AnimatedBuilder(
+      animation: _ctrl,
+      builder: (context, _) {
+        final t = _ctrl.value;
+        return ClipRRect(
+          borderRadius: widget.borderRadius,
+          child: CustomPaint(
+            size: Size(widget.width ?? double.infinity, widget.height),
+            painter: _ShimmerPainter(base, t),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ShimmerPainter extends CustomPainter {
+  final Color base;
+  final double t;
+  _ShimmerPainter(this.base, this.t);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final rect = Offset.zero & size;
+    final light = base.withOpacity(0.55);
+    final dark = base.withOpacity(0.9);
+    final dx = rect.width * (t * 1.5 - 0.25);
+    final gradient = LinearGradient(
+      begin: Alignment(-1 + t * 2, 0),
+      end: Alignment(1 + t * 2, 0),
+      colors: [dark, light, dark],
+      stops: const [0.25, 0.5, 0.75],
+      transform: GradientRotation(-math.pi / 24),
+    );
+    final paint = Paint()..shader = gradient.createShader(rect.translate(dx, 0));
+    canvas.drawRect(rect, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _ShimmerPainter oldDelegate) =>
+      oldDelegate.t != t || oldDelegate.base != base;
+}
+

--- a/lib/common/widgets/soft_card.dart
+++ b/lib/common/widgets/soft_card.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class SoftCard extends StatelessWidget {
+  final Widget child;
+  final EdgeInsetsGeometry padding;
+  final EdgeInsetsGeometry? margin;
+  final VoidCallback? onTap;
+
+  const SoftCard({
+    super.key,
+    required this.child,
+    this.padding = const EdgeInsets.all(16),
+    this.margin,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final isDark = theme.brightness == Brightness.dark;
+    final card = Container(
+      margin: margin,
+      padding: padding,
+      decoration: BoxDecoration(
+        color: scheme.surface,
+        borderRadius: BorderRadius.circular(AppRadii.card),
+        boxShadow: isDark ? null : AppShadows.elevation1,
+        border: isDark
+            ? Border.all(color: AppPalette.borderDark)
+            : null,
+      ),
+      child: child,
+    );
+    if (onTap == null) return card;
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(AppRadii.card),
+        onTap: onTap,
+        child: card,
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/tap_scale.dart
+++ b/lib/common/widgets/tap_scale.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/widgets.dart';
+
+/// Lightweight scale-on-press wrapper that doesn't steal gestures
+/// from inner buttons. Uses Pointer events instead of GestureDetector.
+class TapScale extends StatefulWidget {
+  final Widget child;
+  final double pressedScale;
+  final Duration duration;
+
+  const TapScale({
+    super.key,
+    required this.child,
+    this.pressedScale = 0.98,
+    this.duration = const Duration(milliseconds: 120),
+  });
+
+  @override
+  State<TapScale> createState() => _TapScaleState();
+}
+
+class _TapScaleState extends State<TapScale> with SingleTickerProviderStateMixin {
+  bool _down = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Listener(
+      onPointerDown: (_) => setState(() => _down = true),
+      onPointerUp: (_) => setState(() => _down = false),
+      onPointerCancel: (_) => setState(() => _down = false),
+      child: AnimatedScale(
+        scale: _down ? widget.pressedScale : 1.0,
+        duration: widget.duration,
+        child: widget.child,
+      ),
+    );
+  }
+}
+

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,9 +1,16 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:peopleslab/core/router/nav.dart';
 import 'package:peopleslab/app/main_shell.dart';
+import 'package:peopleslab/features/styleguide/presentation/atoms_demo_page.dart';
+import 'package:peopleslab/features/donation/presentation/donation_amount_page.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+// import 'package:peopleslab/features/donation/presentation/digital_receipt_page.dart';
+import 'package:peopleslab/features/wallet/presentation/wallet_page.dart';
+import 'package:peopleslab/features/study/presentation/study_args.dart';
+import 'package:peopleslab/features/study/presentation/study_page.dart';
 import 'package:peopleslab/features/onboarding/presentation/onboarding_page.dart';
 import 'package:peopleslab/features/onboarding/presentation/welcome_page.dart';
 import 'package:peopleslab/core/di/providers.dart';
@@ -24,6 +31,11 @@ class AppRoutes {
   static const String signUp = '/signup';
   static const String forgotPassword = '/forgot-password';
   static const String home = '/home';
+  static const String styleguideAtoms = '/__styleguide_atoms';
+  static const String donate = '/donate';
+  // static const String receipt = '/receipt'; // no receipts flow for now
+  static const String wallet = '/wallet';
+  static const String study = '/study';
 
   // Optional nested flows kept for existing UI
   static const String emailSignIn = '/signin/email';
@@ -33,6 +45,21 @@ class AppRoutes {
 // Public routes (no auth required)
 const Set<String> publicRoutes = {
   AppRoutes.bootstrap,
+  AppRoutes.welcome,
+  AppRoutes.onboarding,
+  AppRoutes.signIn,
+  AppRoutes.signUp,
+  AppRoutes.forgotPassword,
+  AppRoutes.emailSignIn,
+  AppRoutes.emailSignUp,
+  AppRoutes.styleguideAtoms,
+  AppRoutes.donate,
+  AppRoutes.wallet,
+  AppRoutes.study,
+};
+
+// Entry routes that should redirect to home when already authenticated
+const Set<String> authEntryRoutes = {
   AppRoutes.welcome,
   AppRoutes.onboarding,
   AppRoutes.signIn,
@@ -87,7 +114,7 @@ class RouterNotifier extends ChangeNotifier {
       appLogger.i('Router: unauthenticated -> welcome');
       return AppRoutes.welcome;
     }
-    if (phase == AuthPhase.authenticated && publicRoutes.contains(loc)) {
+    if (phase == AuthPhase.authenticated && authEntryRoutes.contains(loc)) {
       appLogger.i('Router: authenticated -> home');
       return AppRoutes.home;
     }
@@ -110,36 +137,82 @@ final goRouterProvider = Provider<GoRouter>((ref) {
       ),
       GoRoute(
         path: AppRoutes.welcome,
-        builder: (context, state) => const WelcomePage(),
+        pageBuilder: (context, state) => _authPage(const WelcomePage()),
       ),
       GoRoute(
         path: AppRoutes.onboarding,
-        builder: (context, state) => const OnboardingPage(),
+        pageBuilder: (context, state) => _authPage(const OnboardingPage()),
       ),
       GoRoute(
         path: AppRoutes.signIn,
-        builder: (context, state) => const SignInPage(),
+        pageBuilder: (context, state) => _authPage(const SignInPage()),
       ),
       GoRoute(
         path: AppRoutes.signUp,
-        builder: (context, state) => const SignUpPage(),
+        pageBuilder: (context, state) => _authPage(const SignUpPage()),
       ),
       GoRoute(
         path: AppRoutes.emailSignIn,
-        builder: (context, state) => const EmailSignIn(),
+        pageBuilder: (context, state) => _authPage(const EmailSignIn()),
       ),
       GoRoute(
         path: AppRoutes.emailSignUp,
-        builder: (context, state) => const EmailSignUpPage(),
+        pageBuilder: (context, state) => _authPage(const EmailSignUpPage()),
       ),
       GoRoute(
         path: AppRoutes.forgotPassword,
-        builder: (context, state) => const ForgotPasswordPage(),
+        pageBuilder: (context, state) => _authPage(const ForgotPasswordPage()),
       ),
       GoRoute(
         path: AppRoutes.home,
         builder: (context, state) => const MainShell(),
       ),
+      GoRoute(
+        path: AppRoutes.styleguideAtoms,
+        builder: (context, state) => const AtomsDemoPage(),
+      ),
+      GoRoute(
+        path: AppRoutes.study,
+        builder: (context, state) {
+          final args = state.extra as StudyArgs?;
+          if (args == null) {
+            return const Scaffold(body: Center(child: Text('Study args missing')));
+          }
+          return StudyPage(args: args);
+        },
+      ),
+      GoRoute(
+        path: AppRoutes.donate,
+        builder: (context, state) {
+          final args = (state.extra is DonationArgs)
+              ? state.extra as DonationArgs
+              : const DonationArgs(projectTitle: 'Дослідження');
+          return DonationAmountPage(args: args);
+        },
+      ),
+      // Receipts flow disabled
+      GoRoute(
+        path: AppRoutes.wallet,
+        builder: (context, state) => const WalletPage(),
+      ),
     ],
   );
 });
+
+CustomTransitionPage<T> _authPage<T>(Widget child) => CustomTransitionPage<T>(
+      transitionDuration: const Duration(milliseconds: 240),
+      transitionsBuilder: (context, animation, secondaryAnimation, child) {
+        final curved = CurvedAnimation(
+          parent: animation,
+          curve: Curves.easeInOutCubic,
+        );
+        return FadeTransition(
+          opacity: curved,
+          child: ScaleTransition(
+            scale: Tween<double>(begin: 0.98, end: 1.0).animate(curved),
+            child: child,
+          ),
+        );
+      },
+      child: child,
+    );

--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -7,6 +7,8 @@ import 'package:peopleslab/app/main_shell.dart';
 import 'package:peopleslab/features/styleguide/presentation/atoms_demo_page.dart';
 import 'package:peopleslab/features/donation/presentation/donation_amount_page.dart';
 import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+import 'package:peopleslab/features/donation/presentation/donation_success_page.dart';
+import 'package:peopleslab/features/donation/presentation/donation_success_args.dart';
 // import 'package:peopleslab/features/donation/presentation/digital_receipt_page.dart';
 import 'package:peopleslab/features/wallet/presentation/wallet_page.dart';
 import 'package:peopleslab/features/study/presentation/study_args.dart';
@@ -33,6 +35,7 @@ class AppRoutes {
   static const String home = '/home';
   static const String styleguideAtoms = '/__styleguide_atoms';
   static const String donate = '/donate';
+  static const String donationSuccess = '/donate/success';
   // static const String receipt = '/receipt'; // no receipts flow for now
   static const String wallet = '/wallet';
   static const String study = '/study';
@@ -54,6 +57,7 @@ const Set<String> publicRoutes = {
   AppRoutes.emailSignUp,
   AppRoutes.styleguideAtoms,
   AppRoutes.donate,
+  AppRoutes.donationSuccess,
   AppRoutes.wallet,
   AppRoutes.study,
 };
@@ -188,6 +192,16 @@ final goRouterProvider = Provider<GoRouter>((ref) {
               ? state.extra as DonationArgs
               : const DonationArgs(projectTitle: 'Дослідження');
           return DonationAmountPage(args: args);
+        },
+      ),
+      GoRoute(
+        path: AppRoutes.donationSuccess,
+        builder: (context, state) {
+          final args = state.extra as DonationSuccessArgs?;
+          if (args == null) {
+            return const Scaffold(body: Center(child: Text('Missing data')));
+          }
+          return DonationSuccessPage(args: args);
         },
       ),
       // Receipts flow disabled

--- a/lib/core/theme/app_scroll.dart
+++ b/lib/core/theme/app_scroll.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+/// App-wide scroll behavior that enables smooth, bouncy physics on all platforms
+/// and supports mouse/trackpad dragging without glow effects.
+class AppScrollBehavior extends MaterialScrollBehavior {
+  const AppScrollBehavior();
+
+  @override
+  Set<PointerDeviceKind> get dragDevices => {
+        PointerDeviceKind.touch,
+        PointerDeviceKind.mouse,
+        PointerDeviceKind.trackpad,
+        PointerDeviceKind.stylus,
+      };
+
+  @override
+  ScrollPhysics getScrollPhysics(BuildContext context) =>
+      const BouncingScrollPhysics(parent: AlwaysScrollableScrollPhysics());
+}
+

--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -1,24 +1,23 @@
+import 'dart:ui';
+
 import 'package:flutter/material.dart';
-import 'package:peopleslab/core/theme/app_colors.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
 
 class AppTheme {
   AppTheme._();
 
   static ThemeData light() {
-    final colorScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.primary,
-      brightness: Brightness.light,
-    );
+    final colorScheme = _lightScheme();
 
-    final baseTextTheme = Typography.material2021(
-      platform: TargetPlatform.android,
-    ).black;
-
+    final text = _textTheme(colorScheme, Brightness.light);
+    final manrope = GoogleFonts.manropeTextTheme(text);
     return ThemeData(
       useMaterial3: true,
       colorScheme: colorScheme,
-      scaffoldBackgroundColor: colorScheme.surface,
-      textTheme: baseTextTheme,
+      scaffoldBackgroundColor: AppPalette.n100,
+      textTheme: manrope,
+      extensions: const [ExtraColors.light()],
       navigationBarTheme: NavigationBarThemeData(
         height: 56,
         backgroundColor: colorScheme.surface,
@@ -38,8 +37,8 @@ class AppTheme {
       pageTransitionsTheme: const PageTransitionsTheme(
         builders: {
           TargetPlatform.android: ZoomPageTransitionsBuilder(),
-          TargetPlatform.iOS: ZoomPageTransitionsBuilder(),
-          TargetPlatform.macOS: ZoomPageTransitionsBuilder(),
+          TargetPlatform.iOS: CupertinoPageTransitionsBuilder(),
+          TargetPlatform.macOS: CupertinoPageTransitionsBuilder(),
           TargetPlatform.linux: ZoomPageTransitionsBuilder(),
           TargetPlatform.windows: ZoomPageTransitionsBuilder(),
         },
@@ -52,26 +51,14 @@ class AppTheme {
         centerTitle: true,
         surfaceTintColor: Colors.transparent,
       ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.5),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 14,
-          vertical: 12,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide.none,
-        ),
-        hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
-        prefixIconColor: colorScheme.onSurfaceVariant,
-        suffixIconColor: colorScheme.onSurfaceVariant,
-      ),
+      inputDecorationTheme: _inputTheme(colorScheme),
       cardTheme: CardThemeData(
         elevation: 0,
         color: colorScheme.surface,
         surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.card),
+        ),
       ),
       dividerTheme: DividerThemeData(
         color: colorScheme.outlineVariant,
@@ -79,15 +66,19 @@ class AppTheme {
         space: 1,
       ),
       chipTheme: ChipThemeData(
-        side: BorderSide.none,
-        selectedColor: colorScheme.primary.withValues(alpha: 0.12),
-        backgroundColor: colorScheme.surfaceContainerHighest.withValues(
-          alpha: 0.6,
+        side: BorderSide(color: colorScheme.outlineVariant),
+        selectedColor: AppPalette.sky,
+        backgroundColor: colorScheme.surface,
+        labelStyle: TextStyle(
+          color: colorScheme.onSurface,
+          fontSize: AppTextScale.secondary,
+          height: 20 / AppTextScale.secondary,
         ),
-        labelStyle: TextStyle(color: colorScheme.onSurface),
         secondaryLabelStyle: TextStyle(color: colorScheme.onPrimary),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.pill),
+        ),
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
         backgroundColor: colorScheme.surface,
@@ -101,41 +92,52 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
-          textStyle: WidgetStatePropertyAll(
-            baseTextTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
-          ),
+          animationDuration: AppDurations.medium,
+          splashFactory: InkSparkle.splashFactory,
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
           side: WidgetStatePropertyAll(
             BorderSide(color: colorScheme.outlineVariant),
           ),
+          animationDuration: AppDurations.medium,
+          splashFactory: InkSparkle.splashFactory,
         ),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
         ),
       ),
       iconButtonTheme: IconButtonThemeData(
         style: ButtonStyle(
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
         ),
       ),
       listTileTheme: ListTileThemeData(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.control),
+        ),
         selectedColor: colorScheme.primary,
         iconColor: colorScheme.onSurfaceVariant,
       ),
@@ -143,20 +145,15 @@ class AppTheme {
   }
 
   static ThemeData dark() {
-    final colorScheme = ColorScheme.fromSeed(
-      seedColor: AppColors.primaryDark,
-      brightness: Brightness.dark,
-    );
-
-    final baseTextTheme = Typography.material2021(
-      platform: TargetPlatform.android,
-    ).white;
-
+    final colorScheme = _darkScheme();
+    final text = _textTheme(colorScheme, Brightness.dark);
+    final manrope = GoogleFonts.manropeTextTheme(text);
     return ThemeData(
       useMaterial3: true,
       colorScheme: colorScheme,
       scaffoldBackgroundColor: colorScheme.surface,
-      textTheme: baseTextTheme,
+      textTheme: manrope,
+      extensions: const [ExtraColors.dark()],
       navigationBarTheme: NavigationBarThemeData(
         height: 56,
         backgroundColor: colorScheme.surface,
@@ -190,26 +187,14 @@ class AppTheme {
         centerTitle: true,
         surfaceTintColor: Colors.transparent,
       ),
-      inputDecorationTheme: InputDecorationTheme(
-        filled: true,
-        fillColor: colorScheme.surfaceContainerHighest.withValues(alpha: 0.35),
-        contentPadding: const EdgeInsets.symmetric(
-          horizontal: 14,
-          vertical: 12,
-        ),
-        border: OutlineInputBorder(
-          borderRadius: BorderRadius.circular(14),
-          borderSide: BorderSide.none,
-        ),
-        hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
-        prefixIconColor: colorScheme.onSurfaceVariant,
-        suffixIconColor: colorScheme.onSurfaceVariant,
-      ),
+      inputDecorationTheme: _inputTheme(colorScheme),
       cardTheme: CardThemeData(
         elevation: 0,
         color: colorScheme.surface,
         surfaceTintColor: Colors.transparent,
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.card),
+        ),
       ),
       dividerTheme: DividerThemeData(
         color: colorScheme.outlineVariant,
@@ -217,15 +202,19 @@ class AppTheme {
         space: 1,
       ),
       chipTheme: ChipThemeData(
-        side: BorderSide.none,
+        side: BorderSide(color: colorScheme.outlineVariant),
         selectedColor: colorScheme.primary.withValues(alpha: 0.22),
-        backgroundColor: colorScheme.surfaceContainerHighest.withValues(
-          alpha: 0.5,
+        backgroundColor: colorScheme.surface,
+        labelStyle: TextStyle(
+          color: colorScheme.onSurface,
+          fontSize: AppTextScale.secondary,
+          height: 20 / AppTextScale.secondary,
         ),
-        labelStyle: TextStyle(color: colorScheme.onSurface),
         secondaryLabelStyle: TextStyle(color: colorScheme.onPrimary),
-        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(22)),
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.pill),
+        ),
       ),
       bottomNavigationBarTheme: BottomNavigationBarThemeData(
         backgroundColor: colorScheme.surface,
@@ -239,44 +228,205 @@ class AppTheme {
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
-          textStyle: WidgetStatePropertyAll(
-            baseTextTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
-          ),
+          animationDuration: AppDurations.medium,
+          splashFactory: InkSparkle.splashFactory,
         ),
       ),
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
           side: WidgetStatePropertyAll(
             BorderSide(color: colorScheme.outlineVariant),
           ),
+          animationDuration: AppDurations.medium,
+          splashFactory: InkSparkle.splashFactory,
         ),
       ),
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ButtonStyle(
           minimumSize: const WidgetStatePropertyAll(Size.fromHeight(48)),
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
         ),
       ),
       iconButtonTheme: IconButtonThemeData(
         style: ButtonStyle(
           shape: WidgetStatePropertyAll(
-            RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(AppRadii.control),
+            ),
           ),
         ),
       ),
       listTileTheme: ListTileThemeData(
-        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(AppRadii.control),
+        ),
         selectedColor: colorScheme.primary,
         iconColor: colorScheme.onSurfaceVariant,
       ),
+    );
+  }
+
+  static TextTheme _textTheme(ColorScheme scheme, Brightness brightness) {
+    TextStyle base(Color color, double size, double height,
+            [FontWeight weight = FontWeight.w400, double? ls]) =>
+        TextStyle(
+          color: color,
+          fontSize: size,
+          height: height / size,
+          fontWeight: weight,
+          fontFeatures: const [FontFeature.tabularFigures()],
+          letterSpacing: ls,
+        );
+
+    final onSurface = brightness == Brightness.light
+        ? AppPalette.n900
+        : AppPalette.textDark;
+    final onSurfaceSecondary = brightness == Brightness.light
+        ? AppPalette.n700
+        : AppPalette.textDark.withValues(alpha: 0.85);
+
+    return TextTheme(
+      displaySmall: base(onSurface, AppTextScale.display, 40, FontWeight.w700, -0.2),
+      headlineLarge: base(onSurface, AppTextScale.h1, 36, FontWeight.w700, -0.1),
+      headlineMedium: base(onSurface, AppTextScale.h2, 32, FontWeight.w700, -0.1),
+      headlineSmall: base(onSurface, AppTextScale.h3, 28, FontWeight.w600, -0.05),
+      titleLarge: base(onSurface, AppTextScale.title, 24, FontWeight.w700, -0.02),
+      bodyLarge: base(onSurface, AppTextScale.body, 24, FontWeight.w400, 0.0),
+      bodyMedium: base(
+        onSurfaceSecondary,
+        AppTextScale.secondary,
+        20,
+        FontWeight.w500,
+        0.0,
+      ),
+      bodySmall: base(
+        onSurfaceSecondary,
+        AppTextScale.caption,
+        16,
+        FontWeight.w500,
+        0.0,
+      ),
+      labelLarge: base(onSurface, 14, 20, FontWeight.w700, 0.1),
+    );
+  }
+
+  static InputDecorationTheme _inputTheme(ColorScheme scheme) {
+    return InputDecorationTheme(
+      filled: true,
+      fillColor: AppPalette.n100,
+      contentPadding: const EdgeInsets.symmetric(
+        horizontal: 14,
+        vertical: 12,
+      ),
+      hintStyle: TextStyle(color: scheme.onSurfaceVariant),
+      prefixIconColor: scheme.onSurfaceVariant,
+      suffixIconColor: scheme.onSurfaceVariant,
+      border: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadii.control),
+        borderSide: const BorderSide(color: AppPalette.n200),
+      ),
+      enabledBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadii.control),
+        borderSide: const BorderSide(color: AppPalette.n200),
+      ),
+      focusedBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadii.control),
+        borderSide: const BorderSide(color: AppPalette.primary600, width: 1.5),
+      ),
+      errorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadii.control),
+        borderSide: const BorderSide(color: AppPalette.danger, width: 1.2),
+      ),
+      focusedErrorBorder: OutlineInputBorder(
+        borderRadius: BorderRadius.circular(AppRadii.control),
+        borderSide: const BorderSide(color: AppPalette.danger, width: 1.5),
+      ),
+    );
+  }
+
+  static ColorScheme _lightScheme() {
+    return ColorScheme(
+      brightness: Brightness.light,
+      primary: AppPalette.primary600,
+      surfaceTint: AppPalette.primary600,
+      onPrimary: AppPalette.white,
+      primaryContainer: AppPalette.primary500.withValues(alpha: 0.2),
+      onPrimaryContainer: AppPalette.primary700,
+      secondary: AppPalette.primary500,
+      onSecondary: AppPalette.white,
+      secondaryContainer: AppPalette.mint,
+      onSecondaryContainer: AppPalette.n700,
+      tertiary: AppPalette.link,
+      onTertiary: AppPalette.white,
+      tertiaryContainer: AppPalette.lavender,
+      onTertiaryContainer: AppPalette.n700,
+      error: AppPalette.danger,
+      onError: AppPalette.white,
+      errorContainer: const Color(0xFFFFDAD6),
+      onErrorContainer: const Color(0xFF410002),
+      outline: AppPalette.n300,
+      outlineVariant: AppPalette.n200,
+      background: AppPalette.white,
+      onBackground: AppPalette.n900,
+      surface: AppPalette.white,
+      onSurface: AppPalette.n900,
+      surfaceVariant: AppPalette.n100,
+      onSurfaceVariant: AppPalette.n700,
+      inverseSurface: const Color(0xFF121212),
+      onInverseSurface: AppPalette.white,
+      inversePrimary: AppPalette.primary500,
+      shadow: const Color(0xFF000000),
+      scrim: const Color(0xFF000000),
+    );
+  }
+
+  static ColorScheme _darkScheme() {
+    return const ColorScheme(
+      brightness: Brightness.dark,
+      primary: AppPalette.primary500,
+      surfaceTint: AppPalette.primary500,
+      onPrimary: AppPalette.white,
+      primaryContainer: Color(0xFF0E2C20),
+      onPrimaryContainer: AppPalette.primary500,
+      secondary: AppPalette.primary500,
+      onSecondary: AppPalette.white,
+      secondaryContainer: Color(0xFF0E2C20),
+      onSecondaryContainer: AppPalette.white,
+      tertiary: AppPalette.link,
+      onTertiary: AppPalette.white,
+      tertiaryContainer: Color(0xFF14283B),
+      onTertiaryContainer: AppPalette.white,
+      error: AppPalette.danger,
+      onError: AppPalette.white,
+      errorContainer: Color(0xFF8C1717),
+      onErrorContainer: AppPalette.white,
+      outline: AppPalette.borderDark,
+      outlineVariant: AppPalette.borderDark,
+      background: AppPalette.surfaceDark,
+      onBackground: AppPalette.textDark,
+      surface: AppPalette.cardDark,
+      onSurface: AppPalette.textDark,
+      surfaceVariant: Color(0xFF0E1524),
+      onSurfaceVariant: Color(0xFFB9C2D0),
+      inverseSurface: AppPalette.textDark,
+      onInverseSurface: AppPalette.cardDark,
+      inversePrimary: AppPalette.primary500,
+      shadow: Color(0xFF000000),
+      scrim: Color(0xFF000000),
     );
   }
 }

--- a/lib/core/theme/design_tokens.dart
+++ b/lib/core/theme/design_tokens.dart
@@ -1,0 +1,146 @@
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+
+/// Design tokens: colors, spacing, radii, shadows, motion, and typography scales.
+/// These are source-of-truth values used by the Theme and shared widgets.
+class AppPalette {
+  AppPalette._();
+
+  // Primary (bold blue)
+  static const Color primary700 = Color(0xFF1D4ED8); // Blue 700
+  static const Color primary600 = Color(0xFF2563EB); // Blue 600
+  static const Color primary500 = Color(0xFF3B82F6); // Blue 500
+
+  // Accents / backgrounds
+  static const Color mint = Color(0xFFDDF7EC); // legacy secondary (kept)
+  static const Color sky = Color(0xFFE7F0FF); // pale blue selection bg
+  static const Color lavender = Color(0xFFEEE8FF); // info bg
+  static const Color sand = Color(0xFFFFF5CC); // receipt bg
+
+  // Status
+  static const Color success = Color(0xFF16A34A);
+  static const Color warning = Color(0xFFF59E0B);
+  static const Color danger = Color(0xFFDC2626);
+  static const Color link = Color(0xFF0EA5E9);
+
+  // Neutrals (text/borders)
+  static const Color n900 = Color(0xFF0F172A);
+  static const Color n700 = Color(0xFF334155);
+  static const Color n500 = Color(0xFF64748B);
+  static const Color n300 = Color(0xFFCBD5E1);
+  static const Color n200 = Color(0xFFE2E8F0);
+  static const Color n100 = Color(0xFFF1F5F9);
+  static const Color white = Color(0xFFFFFFFF);
+
+  // Dark mode surfaces
+  static const Color surfaceDark = Color(0xFF0B1220);
+  static const Color cardDark = Color(0xFF111827);
+  static const Color borderDark = Color(0xFF243244);
+  static const Color textDark = Color(0xFFEEF2F7);
+}
+
+class AppSpacing {
+  AppSpacing._();
+  static const double xxs = 4;
+  static const double xs = 8;
+  static const double sm = 12;
+  static const double md = 16;
+  static const double lg = 20;
+  static const double xl = 24;
+  static const double xxl = 32;
+}
+
+class AppRadii {
+  AppRadii._();
+  static const double card = 20;
+  static const double control = 12; // inputs/buttons
+  static const double pill = 999; // chips
+}
+
+class AppShadows {
+  AppShadows._();
+  static const List<BoxShadow> elevation1 = [
+    BoxShadow(
+      offset: Offset(0, 2),
+      blurRadius: 10,
+      color: Color.fromRGBO(15, 23, 42, 0.06),
+    ),
+  ];
+  static const List<BoxShadow> elevation2 = [
+    BoxShadow(
+      offset: Offset(0, 6),
+      blurRadius: 24,
+      color: Color.fromRGBO(15, 23, 42, 0.08),
+    ),
+  ];
+}
+
+class AppDurations {
+  AppDurations._();
+  static const Duration color = Duration(milliseconds: 120);
+  static const Duration medium = Duration(milliseconds: 160);
+  static const Duration long = Duration(milliseconds: 240);
+}
+
+class AppCurves {
+  AppCurves._();
+  static const Curve standard = Cubic(0.2, 0.8, 0.2, 1.0);
+}
+
+/// Extra brand/background colors not captured by Material ColorScheme.
+class ExtraColors extends ThemeExtension<ExtraColors> {
+  final Color mint;
+  final Color lavender;
+  final Color sand;
+
+  const ExtraColors({
+    required this.mint,
+    required this.lavender,
+    required this.sand,
+  });
+
+  const ExtraColors.light()
+      : mint = AppPalette.mint,
+        lavender = AppPalette.lavender,
+        sand = AppPalette.sand;
+
+  const ExtraColors.dark()
+      : mint = const Color(0xFF0D3322), // tuned darker mint context
+        lavender = const Color(0xFF2A2540),
+        sand = const Color(0xFF3A3220);
+
+  @override
+  ThemeExtension<ExtraColors> copyWith({
+    Color? mint,
+    Color? lavender,
+    Color? sand,
+  }) => ExtraColors(
+        mint: mint ?? this.mint,
+        lavender: lavender ?? this.lavender,
+        sand: sand ?? this.sand,
+      );
+
+  @override
+  ThemeExtension<ExtraColors> lerp(ThemeExtension<ExtraColors>? other, double t) {
+    if (other is! ExtraColors) return this;
+    return ExtraColors(
+      mint: Color.lerp(mint, other.mint, t)!,
+      lavender: Color.lerp(lavender, other.lavender, t)!,
+      sand: Color.lerp(sand, other.sand, t)!,
+    );
+  }
+}
+
+/// Typography scale (sizes only; weights set in the theme).
+class AppTextScale {
+  AppTextScale._();
+  static const double display = 32; // 32/40
+  static const double h1 = 28; // 28/36
+  static const double h2 = 24; // 24/32
+  static const double h3 = 20; // 20/28
+  static const double title = 18; // 18/24
+  static const double body = 16; // 16/24
+  static const double secondary = 14; // 14/20
+  static const double caption = 12; // 12/16
+}

--- a/lib/features/donation/presentation/digital_receipt_page.dart
+++ b/lib/features/donation/presentation/digital_receipt_page.dart
@@ -1,0 +1,315 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/common/widgets/soft_card.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+import 'package:uuid/uuid.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class ReceiptLine {
+  final String title;
+  final int qty;
+  final double price;
+  final bool discount;
+  const ReceiptLine({
+    required this.title,
+    this.qty = 1,
+    required this.price,
+    this.discount = false,
+  });
+}
+
+class ReceiptData {
+  final String projectTitle;
+  final double amount;
+  final String frequency; // once/monthly
+  final String method; // card/apple/gpay
+  final bool anonymous;
+  final DateTime createdAt;
+  final String transactionId;
+  final List<ReceiptLine> lines;
+
+  const ReceiptData({
+    required this.projectTitle,
+    required this.amount,
+    required this.frequency,
+    required this.method,
+    required this.anonymous,
+    required this.createdAt,
+    required this.transactionId,
+    required this.lines,
+  });
+
+  factory ReceiptData.mock({
+    required String projectTitle,
+    required double amount,
+    required String frequency,
+    required String method,
+    required bool anonymous,
+  }) {
+    final uuid = const Uuid().v4();
+    final lines = <ReceiptLine>[
+      const ReceiptLine(title: 'Статистичний аналіз', qty: 1, price: 265.08),
+      const ReceiptLine(title: 'Лабораторні аналізи', qty: 1, price: 520.00),
+      const ReceiptLine(title: 'Співфінансування грантом', qty: 1, price: -265.08, discount: true),
+    ];
+    return ReceiptData(
+      projectTitle: projectTitle,
+      amount: amount,
+      frequency: frequency,
+      method: method,
+      anonymous: anonymous,
+      createdAt: DateTime.now(),
+      transactionId: uuid.substring(0, 8).toUpperCase(),
+      lines: lines,
+    );
+  }
+
+  double get subtotal =>
+      lines.where((l) => !l.discount).fold(0, (sum, l) => sum + l.price * l.qty);
+  double get discounts =>
+      lines.where((l) => l.discount).fold(0, (sum, l) => sum + l.price * l.qty);
+  double get total => subtotal + discounts;
+}
+
+class DigitalReceiptPage extends StatefulWidget {
+  final ReceiptData data;
+  const DigitalReceiptPage({super.key, required this.data});
+
+  @override
+  State<DigitalReceiptPage> createState() => _DigitalReceiptPageState();
+}
+
+class _DigitalReceiptPageState extends State<DigitalReceiptPage> {
+  bool dontPrint = true; // default ON
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final f = NumberFormat.currency(locale: 'uk_UA', symbol: '₴', decimalDigits: 2);
+    final d = DateFormat('dd.MM.yyyy, HH:mm');
+    final data = widget.data;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Цифровий чек')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Top summary card
+          Container(
+            decoration: BoxDecoration(
+              color: AppPalette.sand,
+              borderRadius: BorderRadius.circular(AppRadii.card),
+              boxShadow: AppShadows.elevation1,
+            ),
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  f.format(data.amount),
+                  style: theme.textTheme.headlineMedium,
+                ),
+                const SizedBox(height: 4),
+                Text('${d.format(data.createdAt)} · ID ${data.transactionId}'),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    // Custom toggle per design tokens
+                    SizedBox(
+                      width: 52,
+                      height: 32,
+                      child: GestureDetector(
+                        onTap: () => setState(() => dontPrint = !dontPrint),
+                        child: _ReceiptToggle(on: dontPrint),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    const Text('Не друкувати чек'),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+
+          // Project title
+          Text(
+            data.projectTitle,
+            style: theme.textTheme.titleLarge,
+          ),
+          const SizedBox(height: 8),
+
+          // Lines
+          SoftCard(
+            child: Column(
+              children: [
+                for (final l in data.lines) ...[
+                  _LineRow(
+                    title: l.title,
+                    qty: l.qty,
+                    price: l.price,
+                    discount: l.discount,
+                  ),
+                  const SizedBox(height: 8),
+                ],
+                const Divider(),
+                const SizedBox(height: 8),
+                _SummaryRow(
+                  label: 'Сума чеку',
+                  value: f.format(data.subtotal),
+                ),
+                _SummaryRow(
+                  label: 'Сума знижки',
+                  value: f.format(data.discounts),
+                  valueStyle: TextStyle(color: AppPalette.success),
+                ),
+                const SizedBox(height: 6),
+                _SummaryRow(
+                  label: 'До оплати',
+                  value: f.format(data.total),
+                  emphasize: true,
+                ),
+              ],
+            ),
+          ),
+
+          const SizedBox(height: 16),
+          Row(
+            children: [
+              Expanded(
+                child: AppButton.outlined(
+                  label: 'Експорт PDF',
+                  onPressed: () => _notify(context, 'PDF збережено'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: AppButton.primary(
+                  label: 'Поділитися',
+                  onPressed: () => _notify(context, 'Посилання скопійовано'),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 24),
+        ],
+      ),
+    );
+  }
+
+  void _notify(BuildContext context, String text) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+  }
+}
+
+class _LineRow extends StatelessWidget {
+  final String title;
+  final int qty;
+  final double price;
+  final bool discount;
+
+  const _LineRow({
+    required this.title,
+    required this.qty,
+    required this.price,
+    this.discount = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final f = NumberFormat.currency(locale: 'uk_UA', symbol: '₴', decimalDigits: 2);
+    final color = discount ? AppPalette.success : Theme.of(context).colorScheme.onSurface;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Expanded(
+          child: Text(
+            qty > 1 ? '$title ×$qty' : title,
+            style: TextStyle(color: color),
+          ),
+        ),
+        Text(
+          f.format(price),
+          style: TextStyle(color: color, fontWeight: FontWeight.w600),
+        ),
+      ],
+    );
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  final String label;
+  final String value;
+  final bool emphasize;
+  final TextStyle? valueStyle;
+  const _SummaryRow({
+    required this.label,
+    required this.value,
+    this.emphasize = false,
+    this.valueStyle,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final style = emphasize
+        ? Theme.of(context).textTheme.titleLarge
+        : Theme.of(context).textTheme.bodyLarge;
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(label, style: style),
+        Text(value, style: valueStyle ?? style?.copyWith(fontWeight: FontWeight.w600)),
+      ],
+    );
+  }
+}
+
+class _ReceiptToggle extends StatelessWidget {
+  final bool on;
+  const _ReceiptToggle({required this.on});
+
+  @override
+  Widget build(BuildContext context) {
+    final track = on ? AppPalette.primary600 : AppPalette.n300;
+    return Stack(
+      alignment: Alignment.center,
+      children: [
+        AnimatedContainer(
+          duration: AppDurations.medium,
+          curve: AppCurves.standard,
+          width: 52,
+          height: 32,
+          decoration: BoxDecoration(
+            color: track,
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+        AnimatedAlign(
+          duration: AppDurations.medium,
+          curve: AppCurves.standard,
+          alignment: on ? Alignment.centerRight : Alignment.centerLeft,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 2),
+            child: Container(
+              width: 28,
+              height: 28,
+              decoration: const BoxDecoration(
+                color: Colors.white,
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                on ? Icons.check_rounded : Icons.close_rounded,
+                size: 16,
+                color: on ? AppPalette.primary600 : AppPalette.n500,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// Uses central AppRoutes from core/router/app_router.dart

--- a/lib/features/donation/presentation/donation_amount_page.dart
+++ b/lib/features/donation/presentation/donation_amount_page.dart
@@ -1,0 +1,246 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/common/widgets/app_filter_chip.dart';
+import 'package:peopleslab/common/widgets/app_text_field.dart';
+import 'package:peopleslab/common/widgets/soft_card.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+import 'package:peopleslab/core/router/app_router.dart';
+import 'package:peopleslab/app/bottom_nav.dart';
+
+class DonationAmountPage extends ConsumerStatefulWidget {
+  final DonationArgs args;
+  const DonationAmountPage({super.key, required this.args});
+
+  @override
+  ConsumerState<DonationAmountPage> createState() => _DonationAmountPageState();
+}
+
+class _DonationAmountPageState extends ConsumerState<DonationAmountPage> {
+  static const double minAmount = 50;
+  static const double maxAmount = 10000;
+  static const List<int> quickSteps = [200, 500, 1000, 2000, 5000];
+
+  double amount = 200;
+  String method = 'card';
+  bool anonymous = false;
+
+  final _amountCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    amount = (widget.args.presetAmount ?? 200).clamp(minAmount, maxAmount);
+    _amountCtrl.text = amount.toStringAsFixed(0);
+  }
+
+  @override
+  void dispose() {
+    _amountCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    return WillPopScope(
+      onWillPop: () async {
+        _restoreTabIfNeeded();
+        return true;
+      },
+      child: Scaffold(
+      appBar: AppBar(title: Text('Підтримати · ${widget.args.projectTitle}')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          // Amount block
+          SoftCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Сума внеску', style: theme.textTheme.titleLarge),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Slider(
+                        value: amount,
+                        min: minAmount,
+                        max: maxAmount,
+                        divisions: ((maxAmount - minAmount) / 50).round(),
+                        label: amount.toStringAsFixed(0),
+                        onChanged: (v) => setState(() {
+                          amount = v;
+                          _amountCtrl.text = amount.toStringAsFixed(0);
+                        }),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    SizedBox(
+                      width: 120,
+                      child: AppTextField(
+                        labelText: 'Сума, ₴',
+                        variant: AppTextFieldVariant.filled,
+                        keyboardType: TextInputType.number,
+                        controller: _amountCtrl,
+                        onChanged: (v) {
+                          final parsed = double.tryParse(v.replaceAll(',', '.'));
+                          if (parsed != null) {
+                            setState(() {
+                              amount = parsed.clamp(minAmount, maxAmount);
+                            });
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: [
+                    for (final s in quickSteps)
+                      AppFilterChip(
+                        label: '$s ₴',
+                        selected: amount.round() == s,
+                        onPressed: () => setState(() {
+                          amount = s.toDouble();
+                          _amountCtrl.text = s.toString();
+                        }),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+
+          // No recurring payments: removed frequency selection
+
+          const SizedBox(height: 16),
+          // Payment methods
+          SoftCard(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Метод оплати', style: theme.textTheme.titleLarge),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    _PayMethodCard(
+                      label: 'Картка',
+                      icon: Icons.credit_card_rounded,
+                      selected: method == 'card',
+                      onTap: () => setState(() => method = 'card'),
+                    ),
+                    const SizedBox(width: 12),
+                    _PayMethodCard(
+                      label: 'Apple Pay',
+                      icon: Icons.phone_iphone_rounded,
+                      selected: method == 'apple',
+                      onTap: () => setState(() => method = 'apple'),
+                    ),
+                    const SizedBox(width: 12),
+                    _PayMethodCard(
+                      label: 'Google Pay',
+                      icon: Icons.android_rounded,
+                      selected: method == 'gpay',
+                      onTap: () => setState(() => method = 'gpay'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Checkbox(
+                      value: anonymous,
+                      onChanged: (v) => setState(() => anonymous = v ?? false),
+                    ),
+                    const SizedBox(width: 4),
+                    const Expanded(child: Text('Публікувати як Анонім')),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 88),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+          child: AppButton.primary(
+            label: 'Підтримати на ${amount.round()} ₴',
+            onPressed: () => _proceed(context),
+          ),
+        ),
+      ),
+      ),
+    );
+  }
+
+  void _proceed(BuildContext context) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Дякуємо за підтримку!')),
+    );
+    _restoreTabIfNeeded();
+    Navigator.of(context).maybePop();
+  }
+
+  void _restoreTabIfNeeded() {
+    final idx = widget.args.returnToTabIndex;
+    if (idx != null) {
+      try {
+        // only if provider exists in scope
+        ref.read(bottomNavIndexProvider.notifier).state = idx;
+      } catch (_) {
+        // ignore if provider not available
+      }
+    }
+  }
+}
+
+class _PayMethodCard extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final bool selected;
+  final VoidCallback? onTap;
+  const _PayMethodCard({
+    required this.label,
+    required this.icon,
+    required this.selected,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final border = selected ? scheme.primary : scheme.outlineVariant;
+    final bg = selected ? scheme.primary.withOpacity(0.04) : scheme.surface;
+    return Expanded(
+      child: Material(
+        color: bg,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: SizedBox(
+            height: 56,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, color: selected ? scheme.primary : scheme.onSurface),
+                const SizedBox(width: 8),
+                Text(label),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/donation/presentation/donation_amount_page.dart
+++ b/lib/features/donation/presentation/donation_amount_page.dart
@@ -7,6 +7,7 @@ import 'package:peopleslab/common/widgets/app_text_field.dart';
 import 'package:peopleslab/common/widgets/soft_card.dart';
 import 'package:peopleslab/core/theme/design_tokens.dart';
 import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+import 'package:peopleslab/features/donation/presentation/donation_success_args.dart';
 import 'package:peopleslab/core/router/app_router.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
 
@@ -184,11 +185,14 @@ class _DonationAmountPageState extends ConsumerState<DonationAmountPage> {
   }
 
   void _proceed(BuildContext context) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Дякуємо за підтримку!')),
+    context.go(
+      AppRoutes.donationSuccess,
+      extra: DonationSuccessArgs(
+        amount: amount,
+        returnToTabIndex: widget.args.returnToTabIndex,
+        projectTitle: widget.args.projectTitle,
+      ),
     );
-    _restoreTabIfNeeded();
-    Navigator.of(context).maybePop();
   }
 
   void _restoreTabIfNeeded() {

--- a/lib/features/donation/presentation/donation_args.dart
+++ b/lib/features/donation/presentation/donation_args.dart
@@ -1,0 +1,11 @@
+class DonationArgs {
+  final String projectTitle;
+  final double? presetAmount;
+  final int? returnToTabIndex; // which bottom tab to restore on back (0=Home,1=Search,...)
+
+  const DonationArgs({
+    required this.projectTitle,
+    this.presetAmount,
+    this.returnToTabIndex,
+  });
+}

--- a/lib/features/donation/presentation/donation_sheet.dart
+++ b/lib/features/donation/presentation/donation_sheet.dart
@@ -1,0 +1,319 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/common/widgets/app_filter_chip.dart';
+import 'package:peopleslab/common/widgets/app_text_field.dart';
+import 'package:peopleslab/common/widgets/soft_card.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+
+Future<void> showDonationSheet(BuildContext context, DonationArgs args) async {
+  await showModalBottomSheet<void>(
+    context: context,
+    isScrollControlled: true,
+    useSafeArea: true,
+    backgroundColor: Colors.transparent,
+    builder: (context) => DonationSheet(args: args),
+  );
+}
+
+class DonationSheet extends StatefulWidget {
+  final DonationArgs args;
+  const DonationSheet({super.key, required this.args});
+
+  @override
+  State<DonationSheet> createState() => _DonationSheetState();
+}
+
+class _DonationSheetState extends State<DonationSheet> {
+  static const double minAmount = 50;
+  static const double maxAmount = 10000;
+  static const List<int> presets = [100, 200, 300, 500, 1000, 2000];
+
+  double amount = 200;
+  String method = 'card';
+  bool anonymous = false;
+  bool customMode = false;
+  final _amountCtrl = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    amount = (widget.args.presetAmount ?? 200).clamp(minAmount, maxAmount);
+    _amountCtrl.text = amount.toStringAsFixed(0);
+  }
+
+  @override
+  void dispose() {
+    _amountCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final media = MediaQuery.of(context);
+    final bottom = media.viewInsets.bottom;
+    return AnimatedPadding(
+      duration: AppDurations.medium,
+      padding: EdgeInsets.only(bottom: bottom),
+      child: Container(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: const BorderRadius.vertical(top: Radius.circular(20)),
+          boxShadow: AppShadows.elevation2,
+        ),
+        child: SafeArea(
+          top: false,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    decoration: BoxDecoration(
+                      color: AppPalette.n200,
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Text('Підтримати · ${widget.args.projectTitle}',
+                    style: theme.textTheme.titleLarge),
+                const SizedBox(height: 12),
+                Flexible(
+                  child: SingleChildScrollView(
+                    child: Column(
+                      children: [
+                        SoftCard(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Row(
+                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                children: [
+                                  Text('Сума внеску', style: theme.textTheme.titleMedium),
+                                  if (customMode)
+                                    TextButton(
+                                      onPressed: () => setState(() => customMode = false),
+                                      child: const Text('Назад до сум'),
+                                    ),
+                                ],
+                              ),
+                              const SizedBox(height: 8),
+                              if (!customMode) ...[
+                                LayoutBuilder(
+                                  builder: (context, constraints) {
+                                    const cols = 3;
+                                    const spacing = 8.0;
+                                    final tileW =
+                                        (constraints.maxWidth - spacing * (cols - 1)) / cols;
+                                    final tiles = <Widget>[];
+                                    for (final s in presets) {
+                                      tiles.add(SizedBox(
+                                        width: tileW,
+                                        height: 40,
+                                        child: _AmountTile(
+                                          label: '$s ₴',
+                                          selected: amount.round() == s,
+                                          onTap: () => setState(() {
+                                            amount = s.toDouble();
+                                            _amountCtrl.text = s.toString();
+                                          }),
+                                        ),
+                                      ));
+                                    }
+                                    tiles.add(SizedBox(
+                                      width: tileW,
+                                      height: 40,
+                                      child: _AmountTile(
+                                        label: 'Інша',
+                                        icon: Icons.edit_rounded,
+                                        selected: false,
+                                        onTap: () => setState(() => customMode = true),
+                                      ),
+                                    ));
+                                    return Wrap(
+                                      spacing: spacing,
+                                      runSpacing: spacing,
+                                      children: tiles,
+                                    );
+                                  },
+                                ),
+                              ] else ...[
+                                AppTextField(
+                                  labelText: 'Сума, ₴',
+                                  variant: AppTextFieldVariant.filled,
+                                  keyboardType: TextInputType.number,
+                                  controller: _amountCtrl,
+                                  onChanged: (v) {
+                                    final parsed = double.tryParse(v.replaceAll(',', '.'));
+                                    if (parsed != null) {
+                                      setState(() {
+                                        amount = parsed.clamp(minAmount, maxAmount);
+                                      });
+                                    }
+                                  },
+                                  helperText: 'Мінімум ${minAmount.toStringAsFixed(0)} ₴, максимум ${maxAmount.toStringAsFixed(0)} ₴',
+                                ),
+                              ],
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        SoftCard(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text('Метод оплати', style: theme.textTheme.titleMedium),
+                              const SizedBox(height: 12),
+                              Row(
+                                children: [
+                                  _PayMethodCard(
+                                    label: 'Картка',
+                                    icon: Icons.credit_card_rounded,
+                                    selected: method == 'card',
+                                    onTap: () => setState(() => method = 'card'),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  _PayMethodCard(
+                                    label: 'Apple Pay',
+                                    icon: Icons.phone_iphone_rounded,
+                                    selected: method == 'apple',
+                                    onTap: () => setState(() => method = 'apple'),
+                                  ),
+                                  const SizedBox(width: 12),
+                                  _PayMethodCard(
+                                    label: 'Google Pay',
+                                    icon: Icons.android_rounded,
+                                    selected: method == 'gpay',
+                                    onTap: () => setState(() => method = 'gpay'),
+                                  ),
+                                ],
+                              ),
+                              const SizedBox(height: 8),
+                              Row(
+                                children: [
+                                  Checkbox(
+                                    value: anonymous,
+                                    onChanged: (v) => setState(() => anonymous = v ?? false),
+                                  ),
+                                  const SizedBox(width: 4),
+                                  const Expanded(child: Text('Публікувати як Анонім')),
+                                ],
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 20),
+                      ],
+                    ),
+                  ),
+                ),
+                AppButton.primary(
+                  label: 'Підтримати на ${amount.round()} ₴',
+                  onPressed: () {
+                    Navigator.of(context).pop();
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Дякуємо за підтримку!')),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PayMethodCard extends StatelessWidget {
+  final String label;
+  final IconData icon;
+  final bool selected;
+  final VoidCallback? onTap;
+  const _PayMethodCard({
+    required this.label,
+    required this.icon,
+    required this.selected,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final bg = selected ? scheme.primary.withOpacity(0.08) : scheme.surface;
+    return Expanded(
+      child: Material(
+        color: bg,
+        borderRadius: BorderRadius.circular(12),
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: SizedBox(
+            height: 56,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(icon, color: selected ? scheme.primary : scheme.onSurface),
+                const SizedBox(width: 8),
+                Text(label),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _AmountTile extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback? onTap;
+  final IconData? icon;
+  const _AmountTile({
+    required this.label,
+    this.selected = false,
+    this.onTap,
+    this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final bg = selected ? scheme.primary.withOpacity(0.10) : scheme.surface;
+    final border = selected ? scheme.primary : scheme.outlineVariant;
+    final fg = selected ? scheme.primary : scheme.onSurface;
+    return Material(
+      color: bg,
+      shape: StadiumBorder(side: BorderSide(color: border)),
+      child: InkWell(
+        onTap: onTap,
+        customBorder: const StadiumBorder(),
+        child: Center(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (icon != null) ...[
+                Icon(icon, size: 16, color: fg),
+                const SizedBox(width: 6),
+              ],
+              Text(
+                label,
+                style: TextStyle(
+                  color: fg,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/donation/presentation/donation_success_args.dart
+++ b/lib/features/donation/presentation/donation_success_args.dart
@@ -1,0 +1,11 @@
+class DonationSuccessArgs {
+  final double amount;
+  final int? returnToTabIndex;
+  final String? projectTitle;
+
+  const DonationSuccessArgs({
+    required this.amount,
+    this.returnToTabIndex,
+    this.projectTitle,
+  });
+}

--- a/lib/features/donation/presentation/donation_success_page.dart
+++ b/lib/features/donation/presentation/donation_success_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/core/router/app_router.dart';
+import 'package:peopleslab/features/donation/presentation/donation_success_args.dart';
+
+class DonationSuccessPage extends StatelessWidget {
+  final DonationSuccessArgs args;
+  const DonationSuccessPage({super.key, required this.args});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(Icons.check_circle_rounded, size: 96, color: scheme.primary),
+              const SizedBox(height: 24),
+              Text(
+                'Дякуємо!',
+                style: Theme.of(context).textTheme.headlineSmall,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Ваш внесок у розмірі ${args.amount.round()} ₴ успішно оформлено.',
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 32),
+              AppButton.primary(
+                label: 'До головної',
+                onPressed: () => context.go(AppRoutes.home),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/home/presentation/home_page.dart
+++ b/lib/features/home/presentation/home_page.dart
@@ -1,7 +1,14 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:peopleslab/common/widgets/search_field.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
+import 'package:peopleslab/common/widgets/search_field.dart';
+import 'package:peopleslab/common/widgets/project_preview_card.dart';
+import 'package:peopleslab/common/widgets/app_filter_chip.dart';
+import 'package:peopleslab/common/widgets/risk_tag.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peopleslab/core/router/app_router.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+import 'package:peopleslab/features/study/presentation/study_args.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({super.key});
@@ -10,29 +17,22 @@ class HomePage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final colorScheme = theme.colorScheme;
-    final categories = const [
-      'Burgers',
-      'Pizza',
-      'Sushi',
-      'Desserts',
-      'Coffee',
-      'Healthy',
-    ];
+    final categories = const ['Трендові', 'Низький ризик', 'RCT', 'Нові'];
     return Scaffold(
       body: SafeArea(
         child: CustomScrollView(
           slivers: [
+            // Removed large header; keep clean content block
             SliverToBoxAdapter(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 8, 16, 8),
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     AppSearchField(
-                      hintText: 'Search restaurants or dishes',
+                      hintText: 'Пошук досліджень або БАДів',
                       onChanged: (_) {},
                       onTap: () {
-                        // Open Search tab when tapping the search field
                         ref.read(bottomNavIndexProvider.notifier).state = 1;
                       },
                       readOnly: true,
@@ -45,9 +45,10 @@ class HomePage extends ConsumerWidget {
                           for (final c in categories)
                             Padding(
                               padding: const EdgeInsets.only(right: 8),
-                              child: FilterChip(
-                                label: Text(c),
-                                onSelected: (_) {},
+                              child: AppFilterChip(
+                                label: c,
+                                selected: c == 'Трендові',
+                                onPressed: () {},
                               ),
                             ),
                         ],
@@ -59,89 +60,47 @@ class HomePage extends ConsumerWidget {
               ),
             ),
             SliverList.builder(
-              itemCount: 6,
+              itemCount: 4,
               itemBuilder: (context, index) {
                 return Padding(
                   padding: const EdgeInsets.symmetric(
-                    horizontal: 16.0,
+                    horizontal: 16,
                     vertical: 8,
                   ),
-                  child: Card(
-                    child: Padding(
-                      padding: const EdgeInsets.all(12.0),
-                      child: Row(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(12),
-                            child: Container(
-                              width: 84,
-                              height: 84,
-                              color: colorScheme.primary.withValues(
-                                alpha: 0.08,
-                              ),
-                              child: Icon(
-                                Icons.restaurant_menu_rounded,
-                                color: colorScheme.primary,
-                              ),
-                            ),
-                          ),
-                          const SizedBox(width: 12),
-                          Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  'Blue Bite • ${categories[index % categories.length]}',
-                                  style: theme.textTheme.titleMedium?.copyWith(
-                                    fontWeight: FontWeight.w600,
-                                  ),
-                                ),
-                                const SizedBox(height: 6),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      Icons.star_rounded,
-                                      size: 18,
-                                      color: Colors.amber[600],
-                                    ),
-                                    const SizedBox(width: 4),
-                                    Text('4.${(index + 3) % 10} • 25-35 min'),
-                                    const SizedBox(width: 8),
-                                    Container(
-                                      padding: const EdgeInsets.symmetric(
-                                        horizontal: 8,
-                                        vertical: 4,
-                                      ),
-                                      decoration: BoxDecoration(
-                                        color: colorScheme.primary.withValues(
-                                          alpha: 0.08,
-                                        ),
-                                        borderRadius: BorderRadius.circular(8),
-                                      ),
-                                      child: Text(
-                                        'Free delivery',
-                                        style: theme.textTheme.labelMedium
-                                            ?.copyWith(
-                                              color: colorScheme.primary,
-                                            ),
-                                      ),
-                                    ),
-                                  ],
-                                ),
-                                const SizedBox(height: 6),
-                                Text(
-                                  'Popular: Chicken bowl, Pepperoni pizza',
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: theme.colorScheme.onSurfaceVariant,
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ],
-                      ),
+                  child: ProjectPreviewCard(
+                    data: ProjectCardData(
+                      title: index.isEven
+                          ? 'Омега‑3 (EPA/DHA)'
+                          : 'Магній (гліцинат)',
+                      subtitle: 'Коротка ціль дослідження та дизайн',
+                      collected: 30000 + index * 5000,
+                      target: 80000,
+                      status: '🧪 Набір',
+                      design: index.isEven ? 'RCT' : 'Observational',
+                      term: '${2 + index} міс',
+                      risk: index % 3 == 0
+                          ? RiskLevel.low
+                          : index % 3 == 1
+                              ? RiskLevel.mid
+                              : RiskLevel.high,
+                      ethicalBoard: index.isEven,
                     ),
+                    onTap: () {
+                      context.push(
+                        AppRoutes.study,
+                        extra: StudyArgs(
+                          id: 'h$index',
+                          title: index.isEven
+                              ? 'Омега‑3 (EPA/DHA)'
+                              : 'Магній (гліцинат)',
+                          goal: 'Коротка ціль дослідження та дизайн',
+                          collected: 30000 + index * 5000,
+                          target: 80000,
+                          ethicalBoard: index.isEven,
+                          endsAt: DateTime.now().add(Duration(days: 20 - index * 2)),
+                        ),
+                      );
+                    },
                   ),
                 );
               },

--- a/lib/features/onboarding/presentation/welcome_page.dart
+++ b/lib/features/onboarding/presentation/welcome_page.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import 'package:peopleslab/core/l10n/l10n_x.dart';
@@ -38,6 +39,13 @@ class WelcomePage extends ConsumerWidget {
                       : () => context.push(AppRoutes.signIn),
                   label: s.cta_already_have_account,
                 ),
+                if (kDebugMode) ...[
+                  const SizedBox(height: 24),
+                  AppButton.outlined(
+                    onPressed: () => context.go(AppRoutes.styleguideAtoms),
+                    label: 'Open Atoms Styleguide',
+                  ),
+                ],
               ],
             ),
           ),

--- a/lib/features/search/presentation/search_page.dart
+++ b/lib/features/search/presentation/search_page.dart
@@ -2,6 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:peopleslab/common/widgets/search_field.dart';
 import 'package:peopleslab/app/bottom_nav.dart';
+import 'package:peopleslab/common/widgets/app_filter_chip.dart';
+import 'package:peopleslab/common/widgets/project_preview_card.dart';
+import 'package:peopleslab/common/widgets/project_card_skeleton.dart';
+import 'package:peopleslab/common/widgets/risk_tag.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peopleslab/core/router/app_router.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+import 'package:peopleslab/features/study/presentation/study_args.dart';
 
 class SearchPage extends ConsumerStatefulWidget {
   const SearchPage({super.key});
@@ -15,14 +23,18 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   final _focusNode = FocusNode();
   final _controller = TextEditingController();
 
-  static const products = <String>[
-    'Vitamin C 1000mg',
-    'Omega-3 Fish Oil',
-    'Magnesium Glycinate',
-    'Whey Protein Powder',
-    'Vitamin D3 5000IU',
-    'Probiotic Complex',
-  ];
+  // Filters
+  bool fTrending = true;
+  bool fLowRisk = false;
+  bool fRCT = false;
+  bool fRecruiting = true;
+  bool fNew = true;
+
+  // Data & loading state
+  final List<ProjectCardData> _items = [];
+  bool _loadingInitial = true;
+  bool _loadingMore = false;
+  final _scrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
@@ -33,43 +45,118 @@ class _SearchPageState extends ConsumerState<SearchPage> {
         if (mounted) _focusNode.requestFocus();
       });
     }
-    final filtered = products
-        .where(
-          (p) =>
-              query.isNotEmpty && p.toLowerCase().contains(query.toLowerCase()),
-        )
-        .toList();
+    _setupScrollListener();
 
     return Scaffold(
       body: SafeArea(
         child: CustomScrollView(
+          controller: _scrollController,
           slivers: [
+            // Removed large header; keep clean content block
             SliverToBoxAdapter(
               child: Padding(
-                padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
-                child: AppSearchField(
-                  hintText: 'Пошук товарів',
-                  controller: _controller,
-                  focusNode: _focusNode,
-                  onChanged: (v) => setState(() => query = v),
+                padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    AppSearchField(
+                      hintText: 'Пошук досліджень або БАДів',
+                      controller: _controller,
+                      focusNode: _focusNode,
+                      onChanged: (v) => setState(() => query = v),
+                    ),
+                    const SizedBox(height: 12),
+                    SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Row(
+                        children: [
+                          AppFilterChip(
+                            label: 'Трендові',
+                            selected: fTrending,
+                            onPressed: () => setState(() => fTrending = !fTrending),
+                          ),
+                          const SizedBox(width: 8),
+                          AppFilterChip(
+                            label: 'Низький ризик',
+                            selected: fLowRisk,
+                            icon: Icons.shield_outlined,
+                            onPressed: () => setState(() => fLowRisk = !fLowRisk),
+                          ),
+                          const SizedBox(width: 8),
+                          AppFilterChip(
+                            label: 'RCT',
+                            selected: fRCT,
+                            onPressed: () => setState(() => fRCT = !fRCT),
+                          ),
+                          const SizedBox(width: 8),
+                          AppFilterChip(
+                            label: 'Набір учасників',
+                            selected: fRecruiting,
+                            onPressed: () => setState(() => fRecruiting = !fRecruiting),
+                          ),
+                          const SizedBox(width: 8),
+                          AppFilterChip(
+                            label: 'Нові',
+                            selected: fNew,
+                            onPressed: () => setState(() => fNew = !fNew),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ),
-            if (filtered.isNotEmpty)
+            if (_loadingInitial)
               SliverList.separated(
-                itemCount: filtered.length,
+                itemCount: 6,
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemBuilder: (context, index) => const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 16),
+                  child: ProjectCardSkeleton(),
+                ),
+              )
+            else
+              SliverList.separated(
+                itemCount: _items.length + (_loadingMore ? 3 : 0),
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
                 itemBuilder: (context, index) {
-                  return ListTile(
-                    title: Text(
-                      filtered[index],
-                      style: theme.textTheme.bodyLarge,
+                  if (index >= _items.length) {
+                    return const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16),
+                      child: ProjectCardSkeleton(),
+                    );
+                  }
+                  final d = _items[index];
+                  final match = query.isEmpty ||
+                      d.title.toLowerCase().contains(query.toLowerCase()) ||
+                      d.subtitle.toLowerCase().contains(query.toLowerCase());
+                  if (!match) {
+                    return const SizedBox.shrink();
+                  }
+                  return Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16),
+                    child: ProjectPreviewCard(
+                      data: d,
+                      onTap: () {
+                        context.push(
+                          AppRoutes.study,
+                          extra: StudyArgs(
+                            id: 's$index',
+                            title: d.title,
+                            goal: d.subtitle,
+                            collected: d.collected,
+                            target: d.target,
+                            ethicalBoard: d.ethicalBoard,
+                            endsAt: d.endsAt,
+                          ),
+                        );
+                      },
                     ),
                   );
                 },
-                separatorBuilder: (_, _) => const Divider(height: 1),
-              )
-            else
-              const SliverToBoxAdapter(child: SizedBox.shrink()),
+              ),
+            const SliverToBoxAdapter(child: SizedBox(height: 24)),
           ],
         ),
       ),
@@ -80,6 +167,76 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   void dispose() {
     _focusNode.dispose();
     _controller.dispose();
+    _scrollController.dispose();
     super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    // Simulate initial fetch
+    Future.delayed(const Duration(milliseconds: 800), () {
+      if (!mounted) return;
+      setState(() {
+        _loadingInitial = false;
+        _items.addAll(_mockBatch(0));
+      });
+    });
+  }
+
+  void _setupScrollListener() {
+    if (_scrollController.hasListeners) return;
+    _scrollController.addListener(() {
+      if (_loadingMore || _loadingInitial) return;
+      final pos = _scrollController.position;
+      if (pos.pixels > pos.maxScrollExtent - 600) {
+        _loadMore();
+      }
+    });
+  }
+
+  void _loadMore() {
+    setState(() => _loadingMore = true);
+    Future.delayed(const Duration(milliseconds: 900), () {
+      if (!mounted) return;
+      setState(() {
+        _items.addAll(_mockBatch(_items.length));
+        _loadingMore = false;
+      });
+    });
+  }
+
+  List<ProjectCardData> _mockBatch(int offset) {
+    final list = <ProjectCardData>[];
+    final titles = [
+      'Омега‑3 (EPA/DHA)',
+      'Магній (гліцинат)',
+      'Вітамін D3',
+      'Пробіотики',
+      'Ашваганда',
+      'Куркумін',
+    ];
+    for (int i = 0; i < 8; i++) {
+      final t = titles[(offset + i) % titles.length];
+      final collected = 20000 + ((offset + i) * 1200) % 40000;
+      final target = 60000;
+      list.add(ProjectCardData(
+        title: t,
+        subtitle: 'Вплив на біомаркери у RCT/Observational',
+        collected: collected.toDouble(),
+        target: target.toDouble(),
+        status: '🧪 Набір',
+        design: i.isEven ? 'RCT' : 'Observational',
+        term: '${2 + (i % 4)} міс',
+        risk: i % 3 == 0
+            ? RiskLevel.low
+            : i % 3 == 1
+                ? RiskLevel.mid
+                : RiskLevel.high,
+        ethicalBoard: i % 2 == 0,
+        endsAt: DateTime.now().add(Duration(days: 30 - ((offset + i) % 15))),
+      ));
+    }
+    return list;
   }
 }

--- a/lib/features/study/presentation/study_args.dart
+++ b/lib/features/study/presentation/study_args.dart
@@ -1,0 +1,19 @@
+class StudyArgs {
+  final String id;
+  final String title;
+  final String goal;
+  final bool ethicalBoard;
+  final double collected;
+  final double target;
+  final DateTime? endsAt;
+
+  const StudyArgs({
+    required this.id,
+    required this.title,
+    required this.goal,
+    required this.collected,
+    required this.target,
+    this.ethicalBoard = false,
+    this.endsAt,
+  });
+}

--- a/lib/features/study/presentation/study_page.dart
+++ b/lib/features/study/presentation/study_page.dart
@@ -1,0 +1,266 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/common/widgets/app_linear_progress.dart';
+import 'package:peopleslab/common/widgets/micro_badge.dart';
+import 'package:peopleslab/common/widgets/hero_section.dart';
+import 'package:peopleslab/common/widgets/risk_tag.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+import 'package:peopleslab/features/donation/presentation/donation_sheet.dart';
+import 'package:peopleslab/features/study/presentation/study_args.dart';
+import 'package:peopleslab/features/study/presentation/widgets/budget_row.dart';
+import 'package:peopleslab/features/study/presentation/widgets/schedule_row.dart';
+import 'package:peopleslab/features/study/presentation/widgets/update_card.dart';
+
+class StudyPage extends StatefulWidget {
+  final StudyArgs args;
+  const StudyPage({super.key, required this.args});
+
+  @override
+  State<StudyPage> createState() => _StudyPageState();
+}
+
+class _StudyPageState extends State<StudyPage> with TickerProviderStateMixin {
+  late final TabController _tab;
+  Duration _left = Duration.zero;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _tab = TabController(length: 6, vsync: this);
+    _updateLeft();
+    _timer = Timer.periodic(const Duration(seconds: 1), (_) => _updateLeft());
+  }
+
+  @override
+  void dispose() {
+    _tab.dispose();
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  void _updateLeft() {
+    final end = widget.args.endsAt;
+    if (end == null) return;
+    final now = DateTime.now();
+    setState(() {
+      _left = end.isAfter(now) ? end.difference(now) : Duration.zero;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final d = widget.args;
+    final progress = (d.collected / d.target).clamp(0.0, 1.0);
+    final pct = (progress * 100).round();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Картка дослідження'),
+      ),
+      body: Column(
+        children: [
+          // Hero block
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: HeroSection(
+              title: Text(d.title, style: Theme.of(context).textTheme.headlineMedium),
+              subtitle: Text(d.goal),
+              chips: const [
+                RiskTag(level: RiskLevel.low, dense: true),
+                MicroBadge(text: 'Етична рада', tone: BadgeTone.success, icon: Icons.verified_outlined),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: Column(
+              children: [
+                AppLinearProgress(value: progress, label: '$pct%'),
+                const SizedBox(height: 6),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text('₴${d.collected.toStringAsFixed(0)} з ₴${d.target.toStringAsFixed(0)}'),
+                    if (widget.args.endsAt != null)
+                      Row(
+                        children: [
+                          const Icon(Icons.timer_rounded, size: 16, color: Color(0xFF64748B)),
+                          const SizedBox(width: 4),
+                          Text(_formatLeft(), style: Theme.of(context).textTheme.bodySmall),
+                        ],
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 12),
+          // Tabs
+          TabBar(
+            controller: _tab,
+            isScrollable: true,
+            tabs: const [
+              Tab(text: 'Огляд'),
+              Tab(text: 'Протокол'),
+              Tab(text: 'Прогрес'),
+              Tab(text: 'Витрати'),
+              Tab(text: 'Дані'),
+              Tab(text: 'Оновлення'),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Expanded(
+            child: TabBarView(
+              controller: _tab,
+              children: [
+                _OverviewTab(args: d),
+                _ProtocolTab(),
+                _ProgressTab(),
+                _CostsTab(),
+                _DataTab(),
+                _UpdatesTab(),
+              ],
+            ),
+          ),
+        ],
+      ),
+      bottomNavigationBar: SafeArea(
+        top: false,
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+          child: AppButton.primary(
+            label: 'Підтримати',
+            onPressed: () => showDonationSheet(
+              context,
+              DonationArgs(projectTitle: d.title, presetAmount: 200),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _toast(BuildContext context, String text) {
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+  }
+}
+
+extension on _StudyPageState {
+  String _formatLeft() {
+    if (_left == Duration.zero) return 'завершено';
+    final d = _left.inDays;
+    final h = _left.inHours % 24;
+    final m = _left.inMinutes % 60;
+    if (d > 0) return '$d д $h г';
+    if (h > 0) return '$h г $m хв';
+    return '$m хв';
+  }
+}
+
+class _OverviewTab extends StatelessWidget {
+  final StudyArgs args;
+  const _OverviewTab({required this.args});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: const [
+        Text('Мета дослідження'),
+        SizedBox(height: 8),
+        Text('Короткий опис, критерії включення, основні біомаркери.'),
+      ],
+    );
+  }
+}
+
+class _ProtocolTab extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final today = DateTime.now();
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: [
+        ScheduleRow(
+          date: today,
+          slots: const [
+            ProtocolSlot(title: 'Опитник', subtitle: '3 хв', time: '09:00–09:05'),
+            ProtocolSlot(title: 'Забір крові', subtitle: '15 хв', time: '10:00–10:15', overdue: true),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ScheduleRow(
+          date: today.add(const Duration(days: 1)),
+          slots: const [
+            ProtocolSlot(title: 'Опитник', subtitle: '3 хв', time: '09:00–09:05', completed: true),
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+class _ProgressTab extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: const [
+        Text('Графіки прогресу, воронка набору тощо.'),
+      ],
+    );
+  }
+}
+
+class _CostsTab extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: const [
+        BudgetRow(title: 'Лабораторні аналізи', amount: 120000, fraction: 0.55),
+        SizedBox(height: 12),
+        BudgetRow(title: 'Статистичний аналіз', amount: 40000, fraction: 0.3),
+        SizedBox(height: 12),
+        BudgetRow(title: 'Адміністративні', amount: 15000, fraction: 0.15),
+      ],
+    );
+  }
+}
+
+class _DataTab extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: const [
+        Text('Публікації, Peer-reviewed / Preprint, відкриті набори даних.'),
+      ],
+    );
+  }
+}
+
+class _UpdatesTab extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+      children: const [
+        UpdateCard(
+          title: 'Проміжні результати аналізу біомаркерів',
+          excerpt: 'Попередні дані показують покращення профілю ліпідів у групі EPA/DHA...',
+        ),
+        SizedBox(height: 12),
+        UpdateCard(
+          title: 'Закуплено реактиви',
+          excerpt: 'Поставка на 3 тижні роботи лабораторії вже у нас.',
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/study/presentation/widgets/budget_row.dart
+++ b/lib/features/study/presentation/widgets/budget_row.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/app_linear_progress.dart';
+
+class BudgetRow extends StatelessWidget {
+  final String title;
+  final double amount;
+  final double fraction; // 0..1
+  const BudgetRow({super.key, required this.title, required this.amount, required this.fraction});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Expanded(child: Text(title)),
+            Text('₴${amount.toStringAsFixed(2)}'),
+          ],
+        ),
+        const SizedBox(height: 6),
+        AppLinearProgress(value: fraction),
+      ],
+    );
+  }
+}
+

--- a/lib/features/study/presentation/widgets/schedule_row.dart
+++ b/lib/features/study/presentation/widgets/schedule_row.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class ProtocolSlot {
+  final String title; // e.g., "Опитник"
+  final String subtitle; // e.g., "3 хв"
+  final String time; // e.g., "09:00–09:05"
+  final bool completed;
+  final bool overdue;
+  const ProtocolSlot({
+    required this.title,
+    required this.subtitle,
+    required this.time,
+    this.completed = false,
+    this.overdue = false,
+  });
+}
+
+class ScheduleRow extends StatelessWidget {
+  final DateTime date;
+  final List<ProtocolSlot> slots;
+  const ScheduleRow({super.key, required this.date, required this.slots});
+
+  @override
+  Widget build(BuildContext context) {
+    final weekday = _weekday(date);
+    final day = date.day.toString().padLeft(2, '0');
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: AppPalette.n100,
+            borderRadius: BorderRadius.circular(8),
+            border: Border.all(color: AppPalette.n200),
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(weekday, style: const TextStyle(fontSize: 10)),
+              Text(day, style: const TextStyle(fontWeight: FontWeight.w700)),
+            ],
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            children: [
+              for (final s in slots) ...[
+                _SlotCard(slot: s),
+                const SizedBox(height: 8),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _weekday(DateTime d) {
+    const list = ['ПН', 'ВТ', 'СР', 'ЧТ', 'ПТ', 'СБ', 'НД'];
+    return list[d.weekday - 1];
+  }
+}
+
+class _SlotCard extends StatelessWidget {
+  final ProtocolSlot slot;
+  const _SlotCard({required this.slot});
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final border = slot.overdue ? AppPalette.warning : scheme.outlineVariant;
+    final fg = slot.completed ? scheme.onSurface.withOpacity(0.6) : scheme.onSurface;
+    return Container(
+      decoration: BoxDecoration(
+        color: scheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: border),
+      ),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      child: Row(
+        children: [
+          Icon(
+            slot.completed ? Icons.check_circle_rounded : Icons.assignment_outlined,
+            color: slot.completed ? AppPalette.success : scheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(slot.title, style: TextStyle(color: fg)),
+                const SizedBox(height: 2),
+                Text(slot.subtitle, style: Theme.of(context).textTheme.bodySmall),
+              ],
+            ),
+          ),
+          const SizedBox(width: 8),
+          Text(slot.time, style: TextStyle(color: fg)),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/features/study/presentation/widgets/update_card.dart
+++ b/lib/features/study/presentation/widgets/update_card.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/micro_badge.dart';
+import 'package:peopleslab/core/theme/design_tokens.dart';
+
+class UpdateCard extends StatelessWidget {
+  final String title;
+  final String excerpt;
+  final String? imageUrl; // optional
+  final VoidCallback? onTap;
+
+  const UpdateCard({
+    super.key,
+    required this.title,
+    required this.excerpt,
+    this.imageUrl,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Material(
+      color: scheme.surface,
+      borderRadius: BorderRadius.circular(AppRadii.card),
+      elevation: 0,
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(AppRadii.card),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              ClipRRect(
+                borderRadius: BorderRadius.circular(12),
+                child: AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: Container(
+                    color: AppPalette.lavender,
+                    child: imageUrl == null
+                        ? const Icon(Icons.image_rounded, size: 48, color: Colors.white70)
+                        : Image.network(imageUrl!, fit: BoxFit.cover),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              const MicroBadge(text: 'Оновлення', tone: BadgeTone.info, icon: Icons.update_rounded),
+              const SizedBox(height: 8),
+              Text(
+                title,
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                excerpt,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/features/styleguide/presentation/atoms_demo_page.dart
+++ b/lib/features/styleguide/presentation/atoms_demo_page.dart
@@ -1,0 +1,211 @@
+import 'package:flutter/material.dart';
+import 'package:peopleslab/common/widgets/app_button.dart';
+import 'package:peopleslab/common/widgets/app_checkbox.dart';
+import 'package:peopleslab/common/widgets/app_radio.dart';
+import 'package:peopleslab/common/widgets/app_text_field.dart';
+import 'package:peopleslab/common/widgets/app_toggle.dart';
+import 'package:peopleslab/common/widgets/app_filter_chip.dart';
+import 'package:peopleslab/common/widgets/app_linear_progress.dart';
+import 'package:peopleslab/common/widgets/app_circular_progress.dart';
+import 'package:peopleslab/common/widgets/risk_tag.dart';
+import 'package:peopleslab/common/widgets/soft_card.dart';
+import 'package:peopleslab/common/widgets/project_preview_card.dart';
+import 'package:go_router/go_router.dart';
+import 'package:peopleslab/core/router/app_router.dart';
+import 'package:peopleslab/features/donation/presentation/donation_args.dart';
+
+class AtomsDemoPage extends StatefulWidget {
+  const AtomsDemoPage({super.key});
+
+  @override
+  State<AtomsDemoPage> createState() => _AtomsDemoPageState();
+}
+
+class _AtomsDemoPageState extends State<AtomsDemoPage> {
+  bool toggle = true;
+  bool checked = false;
+  String radio = 'once';
+  bool chipSelected = true;
+  double pct = 0.63;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Atoms Demo'),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          Text('Buttons', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: const [
+              SizedBox(
+                width: 200,
+                child: AppButton.primary(label: 'Підтримати'),
+              ),
+              SizedBox(
+                width: 200,
+                child: AppButton.outlined(label: 'Узяти участь'),
+              ),
+              AppButton.text(label: 'Деталі'),
+              SizedBox(
+                width: 200,
+                child: AppButton.destructive(label: 'Видалити'),
+              ),
+            ],
+          ),
+
+          const SizedBox(height: 24),
+          Text('Inputs', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          const AppTextField(
+            labelText: 'Пошта',
+            hintText: 'name@example.com',
+            variant: AppTextFieldVariant.outline,
+            prefixIcon: Icon(Icons.alternate_email_rounded),
+          ),
+          const SizedBox(height: 12),
+          const AppTextField(
+            labelText: 'Пароль',
+            hintText: '••••••••',
+            obscureText: true,
+            variant: AppTextFieldVariant.filled,
+            prefixIcon: Icon(Icons.lock_outline_rounded),
+          ),
+          const SizedBox(height: 12),
+          const AppTextField(
+            labelText: 'Коментар',
+            hintText: 'Ваш відгук',
+            variant: AppTextFieldVariant.multiline,
+          ),
+
+          const SizedBox(height: 24),
+          Text('Chips & Tags', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 8,
+            runSpacing: 8,
+            children: [
+              AppFilterChip(
+                label: 'Низький ризик',
+                selected: chipSelected,
+                icon: Icons.shield_outlined,
+                onPressed: () => setState(() => chipSelected = !chipSelected),
+              ),
+              const AppFilterChip(
+                label: 'RCT',
+                selected: false,
+              ),
+              const RiskTag(level: RiskLevel.low),
+              const RiskTag(level: RiskLevel.mid),
+              const RiskTag(level: RiskLevel.high),
+            ],
+          ),
+
+          const SizedBox(height: 24),
+          Text('Progress', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          AppLinearProgress(value: pct, label: '${(pct * 100).round()}%'),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              AppCircularProgress(
+                value: pct,
+                center: const Icon(Icons.emoji_events_rounded, size: 28),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: const [
+                    Text('Рівень 3'),
+                    Text('Нагороди: бейдж, ранній доступ'),
+                  ],
+                ),
+              )
+            ],
+          ),
+
+          const SizedBox(height: 24),
+          Text('Soft Card', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          const SoftCard(
+            child: Text('Пухка картка з м’якою тінню'),
+          ),
+
+          const SizedBox(height: 24),
+          Text('Toggles & Checks', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 24),
+          Text('Project Card', style: Theme.of(context).textTheme.titleLarge),
+          const SizedBox(height: 12),
+          ProjectPreviewCard(
+            data: ProjectCardData(
+              title: 'Омега‑3 (EPA/DHA)',
+              subtitle: 'Вплив на профіль ліпідів у RCT',
+              collected: 45000,
+              target: 80000,
+              status: '🧪 Набір',
+              design: 'RCT',
+              term: '3 міс',
+              risk: RiskLevel.low,
+              ethicalBoard: true,
+              endsAt: null,
+            ),
+            onTap: () {},
+          ),
+          const SizedBox(height: 12),
+          AppButton.outlined(
+            label: 'Відкрити «Панель донату»',
+            onPressed: () => context.push(
+              AppRoutes.donate,
+              extra: const DonationArgs(projectTitle: 'Омега‑3 (EPA/DHA)'),
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              AppToggle(
+                value: toggle,
+                showIcons: true,
+                semanticsLabel: 'Не друкувати чек',
+                onChanged: (v) => setState(() => toggle = v),
+              ),
+              const SizedBox(width: 12),
+              Text(toggle ? 'ON' : 'OFF'),
+            ],
+          ),
+          const SizedBox(height: 12),
+          AppCheckbox(
+            value: checked,
+            label: 'Публікувати як Анонім',
+            onChanged: (v) => setState(() => checked = v),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 16,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: [
+              AppRadio<String>(
+                value: 'once',
+                groupValue: radio,
+                label: 'Разово',
+                onChanged: (v) => setState(() => radio = v),
+              ),
+              AppRadio<String>(
+                value: 'monthly',
+                groupValue: radio,
+                label: 'Щомісяця',
+                onChanged: (v) => setState(() => radio = v),
+              ),
+            ],
+          ),
+          const SizedBox(height: 64),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/wallet/presentation/wallet_page.dart
+++ b/lib/features/wallet/presentation/wallet_page.dart
@@ -1,0 +1,114 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:peopleslab/common/widgets/soft_card.dart';
+import 'package:peopleslab/features/study/presentation/widgets/budget_row.dart';
+
+class WalletPage extends StatefulWidget {
+  const WalletPage({super.key});
+
+  @override
+  State<WalletPage> createState() => _WalletPageState();
+}
+
+class _WalletPageState extends State<WalletPage> {
+  final List<_Tx> _items = _mockTx();
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final f = NumberFormat.currency(locale: 'uk_UA', symbol: '₴', decimalDigits: 0);
+
+    final total = _items.fold<double>(0, (s, t) => s + t.amount);
+    double _lastNDays(int days) {
+      final threshold = DateTime.now().subtract(Duration(days: days));
+      return _items
+          .where((t) => t.time.isAfter(threshold))
+          .fold<double>(0, (s, t) => s + t.amount);
+    }
+    final perProject = <String, double>{};
+    for (final t in _items) {
+      perProject.update(t.project, (v) => v + t.amount, ifAbsent: () => t.amount);
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Кошелек')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          SoftCard(
+            child: Row(
+              children: [
+                const Icon(Icons.account_balance_wallet_rounded),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Сума внесків', style: theme.textTheme.bodySmall),
+                      Text(f.format(total), style: theme.textTheme.titleLarge),
+                      const SizedBox(height: 6),
+                      Text('Останні 30 днів: ${f.format(_lastNDays(30))}',
+                          style: theme.textTheme.bodySmall),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text('Розподіл по проєктах', style: theme.textTheme.titleLarge),
+          const SizedBox(height: 12),
+          for (final entry in perProject.entries) ...[
+            BudgetRow(
+              title: entry.key,
+              amount: entry.value,
+              fraction: total > 0 ? (entry.value / total) : 0,
+            ),
+            const SizedBox(height: 12),
+          ],
+          const SizedBox(height: 12),
+        ],
+      ),
+    );
+  }
+}
+
+class _Tx {
+  final String id;
+  final String project;
+  final double amount;
+  final DateTime time;
+  final String freq;
+  final String method;
+  _Tx({
+    required this.id,
+    required this.project,
+    required this.amount,
+    required this.time,
+    required this.freq,
+    required this.method,
+  });
+}
+
+List<_Tx> _mockTx() {
+  final rnd = Random(1);
+  final projs = ['Омега‑3 (EPA/DHA)', 'Магній (гліцинат)', 'Вітамін D3'];
+  final list = <_Tx>[];
+  for (int i = 0; i < 10; i++) {
+    final p = projs[i % projs.length];
+    final amt = [200, 500, 1000, 1500, 2000][i % 5].toDouble();
+    const freq = 'once';
+    final method = ['card', 'card', 'card'][i % 3];
+    list.add(_Tx(
+      id: 'TX${100000 + i}',
+      project: p,
+      amount: amt,
+      time: DateTime.now().subtract(Duration(days: i * 2, hours: rnd.nextInt(12))),
+      freq: freq,
+      method: method,
+    ));
+  }
+  return list;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -181,6 +181,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.2.1"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: ebc94ed30fd13cefd397cb1658b593f21571f014b7d1197eeb41fb95f05d899a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.1"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -217,10 +225,10 @@ packages:
     dependency: transitive
     description:
       name: google_sign_in_platform_interface
-      sha256: "8736443134d2cccadd4f228d600177cb3947e36683466a6ab96877ce6932885a"
+      sha256: "7f59208c42b415a3cca203571128d6f84f885fead2d5b53eb65a9e27f2965bb5"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.0"
   google_sign_in_web:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   sign_in_with_apple: ^7.0.1
   go_router: ^16.2.1
   intl: ^0.20.2
+  google_fonts: ^6.2.1
 
   # ВАЖЛИВО: тимчасово тримаємо 4.1.x, бо grpc >=4.2.0 вимагає meta ^1.17.0,
   # а flutter_test у твоєму SDK пінить meta на 1.16.0.

--- a/test/features/donation/presentation/donation_success_page_test.dart
+++ b/test/features/donation/presentation/donation_success_page_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:peopleslab/features/donation/presentation/donation_success_args.dart';
+import 'package:peopleslab/features/donation/presentation/donation_success_page.dart';
+
+void main() {
+  testWidgets('shows amount in message', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DonationSuccessPage(
+          args: DonationSuccessArgs(amount: 100),
+        ),
+      ),
+    );
+    expect(
+      find.text('Ваш внесок у розмірі 100 ₴ успішно оформлено.'),
+      findsOneWidget,
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add donation success arguments and page
- route donation completion to new success screen
- cover success page with widget test

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c180b37c2c833194008cdb3f539a8a